### PR TITLE
Implement playable turn flow UI and add gameplay Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
 # terraform-trek
-A rouge-like game built in Lua and Love2d inspired by Terraform Mars
+A rogue-like game built in Lua and Love2d inspired by Terraforming Mars.
+
+## Current Prototype Loop
+
+The current gameplay prototype is a simple card-driven terraforming system:
+
+- Four terraform primitives: `Heat`, `Air`, `Water`, `Soil` (range `-4` to `+4`)
+- A target value for each primitive per world
+- One output meter: `Habitability`
+- End-turn hazards (intent shown in the HUD)
+- End-turn coupling rules where extreme stats push other stats
+- Three sequential worlds: low threat, elite, boss
+
+### Flow Diagram
+
+See `/Users/garypeters/Documents/GitHub/terraform-trek/gameplay_flow.mmd` for the full gameplay flow diagram.
+
+```mermaid
+flowchart TD
+    A["Start Run (R)"] --> B["Setup World"]
+    B --> C["Terraforming state + starter deck setup"]
+    C --> D["Turn loop"]
+    D --> E{"Play card or end turn?"}
+    E -->|Play card| F["Apply card effect + spend energy + discard card"]
+    F --> D
+    E -->|End turn| G["Apply hazard + coupling + habitability scoring"]
+    G --> H{"World status"}
+    H -->|Ongoing| I["Discard hand + draw 5 + reset energy"]
+    I --> D
+    H -->|World won| J{"Last world?"}
+    J -->|No| K["Next world"]
+    K --> B
+    J -->|Yes| L["Campaign won"]
+    H -->|Lost| M["Campaign lost"]
+```
+
+### Controls
+
+- Click a card or press `1-9`: play card from hand
+- Click `END TURN` or press `E`: end turn
+- `N`: go to next world after a world victory
+- `R`: restart run
 
 ## Running Locally
 

--- a/card.lua
+++ b/card.lua
@@ -48,11 +48,13 @@ function Card:draw(x, y)
   
   -- Determine category color
   local category_color = {0.5, 0.5, 0.5} -- Default gray
-  if self.category == "Attack" then
-    category_color = {1, 0, 0} -- Red
-  elseif self.category == "Skill" then
-    category_color = {0, 0, 1} -- Blue
-  end -- Add more categories later if needed
+  if self.category == "Terraform" then
+    category_color = {0.05, 0.55, 0.25}
+  elseif self.category == "Chance" then
+    category_color = {0.1, 0.35, 0.7}
+  elseif self.category == "Power" then
+    category_color = {0.6, 0.25, 0.1}
+  end
 
   -- 1. Draw background
   gfx.setColor(bg_color[1], bg_color[2], bg_color[3])

--- a/card_effects.lua
+++ b/card_effects.lua
@@ -1,52 +1,9 @@
 local CardEffects = {}
 
---[[
-This module contains functions that implement the specific effects of cards when played.
-Each function will receive a 'context' table containing relevant game state information.
-For now, context might include:
-  - context.card: The card object being played.
-  - context.target: The TerraformingTarget object.
-  - context.deck: The player's Deck object.
-  - context.player: (Future) A table representing the player state (e.g., buffs).
-]]
-
--- Effect for cards like Basic Strike, Heavy Strike
-function CardEffects.deal_damage(context)
-  local card = context.card
-  local target = context.target
-  local damage = card.properties.damage or 0
-
-  print("Applying effect: deal_damage")
-  print("  Card: " .. card.name)
-  print("  Damage: " .. damage)
-  -- In the future, this would interact with the target object:
-  -- target:take_damage(damage)
-  -- print("  Target health remaining: " .. target.health)
-end
-
--- Effect for cards like Basic Defend
-function CardEffects.gain_block(context)
-  local card = context.card
-  -- local player = context.player -- We'll need a player object later
-  local block_amount = card.properties.block_amount or 0
-
-  print("Applying effect: gain_block")
-  print("  Card: " .. card.name)
-  print("  Block Amount: " .. block_amount)
-  -- In the future, this would modify player state:
-  -- player:add_block(block_amount)
-  -- print("  Player block: " .. player.block)
-end
-
--- Effect for cards like Draw Cards
 function CardEffects.draw_cards(context)
   local card = context.card
   local deck = context.deck
   local draw_amount = card.properties.draw_amount or 0
-
-  print("Applying effect: draw_cards")
-  print("  Card: " .. card.name)
-  print("  Draw Amount: " .. draw_amount)
 
   if deck and draw_amount > 0 then
     deck:draw(draw_amount)
@@ -55,21 +12,26 @@ function CardEffects.draw_cards(context)
   end
 end
 
--- Effect for cards like Gain Strength, Gain Dexterity
-function CardEffects.apply_buff(context)
+function CardEffects.apply_stat_changes(context)
   local card = context.card
-  -- local player = context.player -- Need player state
-  local buff_type = card.properties.buff_type
-  local buff_amount = card.properties.buff_amount or 0
-  local duration = card.properties.duration -- Not used yet
+  local terraforming_state = context.terraforming_state
+  if not terraforming_state then
+    print("Warning: Missing terraforming_state in card context.")
+    return
+  end
 
-  print("Applying effect: apply_buff")
-  print("  Card: " .. card.name)
-  print("  Buff Type: " .. tostring(buff_type))
-  print("  Amount: " .. buff_amount)
-  print("  Duration: " .. tostring(duration))
-  -- In the future, modify player state:
-  -- player:apply_buff(buff_type, buff_amount, duration)
+  local stat_changes = card.properties.stat_changes or {}
+  terraforming_state:apply_player_changes(stat_changes)
 end
 
-return CardEffects 
+function CardEffects.stabilize_system(context)
+  local terraforming_state = context.terraforming_state
+  if not terraforming_state then
+    print("Warning: Missing terraforming_state in card context.")
+    return
+  end
+
+  terraforming_state:adjust_toward_targets(1)
+end
+
+return CardEffects

--- a/card_types.lua
+++ b/card_types.lua
@@ -1,111 +1,156 @@
 local CardTypes = {}
 
--- Base card type definitions (Renamed categories)
+-- Base card type definitions
 CardTypes.BaseTypes = {
-    TERRAFORM = {
+    Terraform = {
         category = "Terraform",
         base_properties = {
-            -- Define base terraform properties if any, e.g., target_type?
             energy_cost = 1
         }
     },
-    CHANCE = {
+    Chance = {
         category = "Chance",
         base_properties = {
-            -- Define base chance properties if any
             energy_cost = 1
         }
     },
-    POWER = { -- Keeping Power for now, can remove later if not needed
+    Power = {
         category = "Power",
         base_properties = {
-            duration = 1,
             energy_cost = 1
         }
     }
 }
 
--- Specific card definitions with IDs and effect function names
+-- Specific card definitions with IDs and effect function names.
 CardTypes.Cards = {
-    -- Terraform Cards (Previously Attack)
-    basic_strike = { -- Using snake_case for IDs
-        id = "basic_strike",
-        name = "Basic Strike",
-        description = "Deal 6 damage to the target.",
-        category = "Terraform", -- Renamed
+    heat_up = {
+        id = "heat_up",
+        name = "Solar Mirrors",
+        description = "Heat +2.",
+        category = "Terraform",
         cost = 1,
-        effect_fn_name = "deal_damage", -- Effect function name
+        effect_fn_name = "apply_stat_changes",
         properties = {
-            damage = 6
+            stat_changes = {
+                heat = 2
+            }
         }
     },
-    heavy_strike = {
-        id = "heavy_strike",
-        name = "Heavy Strike",
-        description = "Deal 10 damage. Costs 2 energy.",
-        category = "Terraform", -- Renamed
-        cost = 2,
-        effect_fn_name = "deal_damage", -- Same effect, different parameters
-        properties = {
-            damage = 10
-        }
-    },
-
-    -- Chance Cards (Previously Skill)
-    basic_defend = {
-        id = "basic_defend",
-        name = "Basic Defend",
-        description = "Gain 5 block.", -- Need to define what "block" means
-        category = "Chance", -- Renamed
+    heat_down = {
+        id = "heat_down",
+        name = "Orbital Shades",
+        description = "Heat -2.",
+        category = "Terraform",
         cost = 1,
-        effect_fn_name = "gain_block", -- Effect function name
+        effect_fn_name = "apply_stat_changes",
         properties = {
-            block_amount = 5
+            stat_changes = {
+                heat = -2
+            }
         }
     },
-    draw_cards = {
-        id = "draw_cards",
-        name = "Draw Cards",
+    air_up = {
+        id = "air_up",
+        name = "Atmo Seeding",
+        description = "Air +2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                air = 2
+            }
+        }
+    },
+    air_down = {
+        id = "air_down",
+        name = "Carbon Scrub",
+        description = "Air -2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                air = -2
+            }
+        }
+    },
+    water_up = {
+        id = "water_up",
+        name = "Comet Capture",
+        description = "Water +2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                water = 2
+            }
+        }
+    },
+    water_down = {
+        id = "water_down",
+        name = "Drain Basins",
+        description = "Water -2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                water = -2
+            }
+        }
+    },
+    soil_up = {
+        id = "soil_up",
+        name = "Nutrient Dust",
+        description = "Soil +2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                soil = 2
+            }
+        }
+    },
+    soil_down = {
+        id = "soil_down",
+        name = "Strip Mine",
+        description = "Soil -2.",
+        category = "Terraform",
+        cost = 1,
+        effect_fn_name = "apply_stat_changes",
+        properties = {
+            stat_changes = {
+                soil = -2
+            }
+        }
+    },
+    stabilize = {
+        id = "stabilize",
+        name = "Stabilize Grid",
+        description = "Move all stats 1 step toward target.",
+        category = "Chance",
+        cost = 1,
+        effect_fn_name = "stabilize_system",
+        properties = {}
+    },
+    survey = {
+        id = "survey",
+        name = "Deep Survey",
         description = "Draw 2 cards.",
-        category = "Chance", -- Renamed
+        category = "Chance",
         cost = 1,
-        effect_fn_name = "draw_cards", -- Effect function name
+        effect_fn_name = "draw_cards",
         properties = {
             draw_amount = 2
         }
-    },
-
-    -- Power Cards (Keep or modify as needed)
-    gain_strength = {
-        id = "gain_strength",
-        name = "Gain Strength",
-        description = "Gain 2 strength for the rest of combat.", -- Define "strength"
-        category = "Power",
-        cost = 1,
-        effect_fn_name = "apply_buff", -- Generic buff function?
-        properties = {
-            duration = -1, -- -1 means permanent
-            buff_type = "strength",
-            buff_amount = 2
-        }
-    },
-    gain_dexterity = {
-        id = "gain_dexterity",
-        name = "Gain Dexterity",
-        description = "Gain 2 dexterity for the rest of combat.", -- Define "dexterity"
-        category = "Power",
-        cost = 1,
-        effect_fn_name = "apply_buff",
-        properties = {
-            duration = -1,
-            buff_type = "dexterity",
-            buff_amount = 2
-        }
     }
 }
 
--- Function to create card data from a type definition (ID)
-function CardTypes.createCardData(cardId) -- Renamed function for clarity
+function CardTypes.createCardData(cardId)
     local cardDef = CardTypes.Cards[cardId]
     if not cardDef then
         error("Invalid card ID: " .. tostring(cardId))
@@ -118,22 +163,19 @@ function CardTypes.createCardData(cardId) -- Renamed function for clarity
         description = cardDef.description,
         category = cardDef.category,
         cost = cardDef.cost,
-        effect_fn_name = cardDef.effect_fn_name, -- Include effect function name
+        effect_fn_name = cardDef.effect_fn_name,
         properties = {}
     }
 
-    -- Merge base properties (if category exists in BaseTypes)
     local baseType = CardTypes.BaseTypes[cardDef.category]
     if baseType and baseType.base_properties then
         for k, v in pairs(baseType.base_properties) do
-            -- Only add base property if not already defined in specific card
             if cardData.properties[k] == nil then
                  cardData.properties[k] = v
             end
         end
     end
 
-    -- Merge specific card properties (overwriting base properties if needed)
     if cardDef.properties then
         for k, v in pairs(cardDef.properties) do
             cardData.properties[k] = v
@@ -143,8 +185,7 @@ function CardTypes.createCardData(cardId) -- Renamed function for clarity
     return cardData
 end
 
--- Function to get all available card IDs
-function CardTypes.getAllCardIds() -- Renamed function for clarity
+function CardTypes.getAllCardIds()
     local ids = {}
     for id, _ in pairs(CardTypes.Cards) do
         table.insert(ids, id)

--- a/deck.lua
+++ b/deck.lua
@@ -22,10 +22,13 @@ function Deck:create_starter_deck()
   self.hand = {}
   self.discard_pile = {}
 
-  -- Define starter deck composition by ID
+  -- Starter deck tuned for bidirectional control on 4 terraform stats.
   local starter_card_ids = {
-    'basic_strike', 'basic_strike', 'basic_strike', 'basic_strike', 'basic_strike', -- 5 Strikes
-    'basic_defend', 'basic_defend', 'basic_defend', 'basic_defend', 'basic_defend'  -- 5 Defends
+    'heat_up', 'heat_up', 'heat_down',
+    'air_up', 'air_down',
+    'water_up', 'water_up', 'water_down',
+    'soil_up', 'soil_down',
+    'stabilize', 'survey'
   }
 
   -- Create card objects from IDs
@@ -85,6 +88,14 @@ function Deck:draw(count)
   print("Drew " .. drawn_count .. " card(s).")
 end
 
+function Deck:discard_hand()
+  local hand_size = #self.hand
+  while #self.hand > 0 do
+    table.insert(self.discard_pile, table.remove(self.hand))
+  end
+  print("Discarded " .. hand_size .. " card(s).")
+end
+
 -- Attempt to play a card from hand, checking energy and executing effects
 -- Returns the card if played successfully, otherwise nil
 -- Accepts a 'context' table containing necessary game state (e.g., context.target)
@@ -113,14 +124,14 @@ function Deck:play_card(card_index, current_energy, context)
   if card.effect_fn_name then
     local effect_func = CardEffects[card.effect_fn_name]
     if effect_func and type(effect_func) == 'function' then
-      -- Prepare context for the effect function
-      local effect_context = {
-        card = card,        -- The card object itself
-        deck = self,        -- The deck instance
-        target = context.target -- Pass the target from the main game loop
-        -- Add other needed context later (e.g., player state)
-      }
-      print("Calling effect function: " .. card.effect_fn_name)
+      -- Merge caller-provided context with base context.
+      local effect_context = {}
+      for k, v in pairs(context) do
+        effect_context[k] = v
+      end
+      effect_context.card = card
+      effect_context.deck = self
+
       effect_func(effect_context) -- Execute the effect
     else
       print("Warning: Effect function '" .. card.effect_fn_name .. "' not found or not a function in CardEffects.")

--- a/gameplay_flow.mmd
+++ b/gameplay_flow.mmd
@@ -1,0 +1,35 @@
+flowchart TD
+    A["Start Run (R)"] --> B["Setup World"]
+    B --> C["Create TerraformingState<br/>- targets<br/>- hazards<br/>- goal / turn limit"]
+    C --> D["Create starter deck<br/>shuffle + draw 5 + reset energy"]
+    D --> E["Player Turn Loop"]
+
+    E --> F["Render HUD<br/>stats + habitability + next hazard<br/>deck (left) + discard (right)"]
+    F --> G{"Player action"}
+
+    G --> H["Play card<br/>(click card or 1-9)"]
+    H --> I{"Enough energy?"}
+    I -->|No| G
+    I -->|Yes| J["Apply card effect<br/>modify Heat/Air/Water/Soil or draw/stabilize"]
+    J --> K["Move card to discard<br/>spend energy"]
+    K --> G
+
+    G --> L["End Turn<br/>(click END TURN or E)"]
+    L --> M["Apply hazard deltas"]
+    M --> N["Apply coupling rules<br/>for extreme stat values"]
+    N --> O["Compute growth - penalty = net"]
+    O --> P["Update habitability"]
+    P --> Q{"World status?"}
+
+    Q -->|Ongoing| R["Discard hand + draw 5<br/>reset energy + next turn"]
+    R --> E
+
+    Q -->|Won| S{"Last world?"}
+    S -->|No| T["World clear overlay<br/>N for next world"]
+    T --> B
+    S -->|Yes| U["Campaign win overlay"]
+
+    Q -->|Lost| V["Campaign loss overlay"]
+    U --> W["Restart (R)"]
+    V --> W
+    W --> A

--- a/main.lua
+++ b/main.lua
@@ -1,282 +1,534 @@
-local Deck = require('deck')
-local TerraformingTarget = require('terraforming_target')
-local DrawHelpers = require('draw_helpers')
-local RelationshipsView = require('planetary_system_relationships') -- Require the new module
-local PlanetarySystem = require('planetary_system_of_equations') -- Require the system module
-local Background = require('background') -- Require the background module
+local Deck = require("deck")
+local TerraformingTarget = require("terraforming_target")
+local DrawHelpers = require("draw_helpers")
+local Background = require("background")
+local TerraformingState = require("terraforming_state")
+
+local STAT_ORDER = { "heat", "air", "water", "soil" }
+local STAT_LABELS = {
+  heat = "Heat",
+  air = "Air",
+  water = "Water",
+  soil = "Soil"
+}
+
+local WORLD_CONFIGS = {
+  {
+    name = "Dustbound Expanse",
+    tier = "Low Threat",
+    goal = 18,
+    turn_limit = 9,
+    hazard_strength = 1,
+    targets = { heat = 0, air = 0, water = 0, soil = 0 }
+  },
+  {
+    name = "Iron Tempest",
+    tier = "Elite",
+    goal = 22,
+    turn_limit = 9,
+    hazard_strength = 1,
+    targets = { heat = 1, air = 0, water = 1, soil = 0 }
+  },
+  {
+    name = "Abyssal Crown",
+    tier = "Boss",
+    goal = 26,
+    turn_limit = 10,
+    hazard_strength = 2,
+    targets = { heat = -1, air = 1, water = 0, soil = 1 }
+  }
+}
 
 local player_deck
+local target
+local terraforming_state
+local world_index = 1
+local campaign_state = "playing" -- playing | world_won | campaign_won | campaign_lost
+local turn_summary = nil
+local hovered_card_index = nil
+local hovered_draw_pile = false
+local hovered_discard_pile = false
+local hovered_end_turn = false
+
 local max_energy = 3
 local current_energy = 0
-local target
-local hovered_card_index = nil
 
--- Create a sample planetary system instance for the relationship view
--- In a real game, you would pass the actual system instance you want to inspect
-local relationship_system_instance = PlanetarySystem.new(
-    {S = 1.0, M = 1.0, T = 1.0, L = 0.8, A = 1.1, H = 0.9, B = 1.2}, 
-    {alpha1 = 0.1, alpha2 = 0.05, beta1 = 0.03} -- Example with some custom coeffs
-)
+local HAND_UI = {
+  card_width = 150,
+  card_height = 225,
+  card_spacing = 175,
+  max_angle_degrees = 10,
+  pixel_offset_per_step = 20,
+  base_y = 430
+}
 
-local gameState = 'gameplay' -- Initial game state
+local PILE_UI = {
+  x_padding = 30,
+  y = 340,
+  width = 110,
+  height = 150
+}
 
--- Helper functions for energy management
+local END_TURN_UI = {
+  width = 170,
+  height = 50,
+  x_padding = 30,
+  y = 520
+}
+
+local function format_signed(value)
+  if value > 0 then
+    return "+" .. tostring(value)
+  end
+  return tostring(value)
+end
+
 local function reset_energy()
   current_energy = max_energy
-  print("Energy reset to " .. current_energy)
 end
 
 local function can_afford(cost)
-  return current_energy >= (cost or 0) -- Treat nil cost as 0
+  return current_energy >= (cost or 0)
 end
 
 local function spend_energy(cost)
   current_energy = current_energy - (cost or 0)
-  print("Spent " .. (cost or 0) .. " energy. Remaining: " .. current_energy)
+end
+
+local function format_delta_list(deltas)
+  local parts = {}
+  for _, key in ipairs(STAT_ORDER) do
+    local delta = (deltas and deltas[key]) or 0
+    if delta ~= 0 then
+      table.insert(parts, STAT_LABELS[key] .. " " .. format_signed(delta))
+    end
+  end
+
+  if #parts == 0 then
+    return "None"
+  end
+
+  return table.concat(parts, "  ")
+end
+
+local function point_in_rect(px, py, rx, ry, rw, rh)
+  return px >= rx and px <= rx + rw and py >= ry and py <= ry + rh
+end
+
+local function get_hand_layout(num_cards)
+  local total_hand_width = 0
+  if num_cards > 0 then
+    total_hand_width = HAND_UI.card_width + (num_cards - 1) * HAND_UI.card_spacing
+  end
+  local start_x = (love.graphics.getWidth() - total_hand_width) / 2
+  return {
+    start_x = start_x,
+    base_y = HAND_UI.base_y
+  }
+end
+
+local function get_draw_pile_rect()
+  return {
+    x = PILE_UI.x_padding,
+    y = PILE_UI.y,
+    w = PILE_UI.width,
+    h = PILE_UI.height
+  }
+end
+
+local function get_discard_pile_rect()
+  return {
+    x = love.graphics.getWidth() - PILE_UI.x_padding - PILE_UI.width,
+    y = PILE_UI.y,
+    w = PILE_UI.width,
+    h = PILE_UI.height
+  }
+end
+
+local function get_end_turn_rect()
+  return {
+    x = love.graphics.getWidth() - END_TURN_UI.x_padding - END_TURN_UI.width,
+    y = END_TURN_UI.y,
+    w = END_TURN_UI.width,
+    h = END_TURN_UI.height
+  }
+end
+
+local function get_card_index_at_position(mx, my)
+  local hand = player_deck.hand
+  local num_cards = #hand
+  local layout = get_hand_layout(num_cards)
+
+  for i = num_cards, 1, -1 do
+    local card_x = layout.start_x + (i - 1) * HAND_UI.card_spacing
+    local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, HAND_UI.pixel_offset_per_step)
+    local current_y = layout.base_y + dy
+
+    if point_in_rect(mx, my, card_x, current_y, HAND_UI.card_width, HAND_UI.card_height) then
+      return i
+    end
+  end
+
+  return nil
+end
+
+local function setup_world(index)
+  world_index = index
+  local config = WORLD_CONFIGS[index]
+  terraforming_state = TerraformingState.new(config)
+  turn_summary = nil
+  campaign_state = "playing"
+
+  player_deck:create_starter_deck()
+  player_deck:draw(5)
+  reset_energy()
+end
+
+local function start_campaign()
+  setup_world(1)
+end
+
+local function end_turn()
+  if campaign_state ~= "playing" then
+    return
+  end
+
+  turn_summary = terraforming_state:end_turn()
+  if terraforming_state.status == "won" then
+    if world_index == #WORLD_CONFIGS then
+      campaign_state = "campaign_won"
+    else
+      campaign_state = "world_won"
+    end
+    return
+  end
+
+  if terraforming_state.status == "lost" then
+    campaign_state = "campaign_lost"
+    return
+  end
+
+  player_deck:discard_hand()
+  player_deck:draw(5)
+  reset_energy()
+end
+
+local function try_play_card(card_index)
+  if campaign_state ~= "playing" then
+    return false
+  end
+
+  local card_to_play = player_deck.hand[card_index]
+  if not card_to_play then
+    return false
+  end
+
+  local cost = card_to_play.cost or 0
+  if not can_afford(cost) then
+    return false
+  end
+
+  local context = {
+    terraforming_state = terraforming_state,
+    target = target
+  }
+  local played_card = player_deck:play_card(card_index, current_energy, context)
+  if played_card then
+    spend_energy(played_card.cost)
+    return true
+  end
+
+  return false
 end
 
 function love.load()
-  -- Set random seed based on time for better shuffling
   love.math.setRandomSeed(os.time())
-  
-  Background.load() -- Load the background first
+  Background.load()
 
-  -- Create and initialize the deck
   player_deck = Deck:new()
-  player_deck:create_starter_deck() -- Creates and shuffles
-  
-  -- Create the target
   target = TerraformingTarget:new()
-  
-  -- Start the first turn
-  reset_energy() 
-  player_deck:draw(5) -- Draw initial hand
-  
-  print("Game Loaded. Initial Hand Drawn. Energy set.")
+  start_campaign()
 end
 
--- Function to draw the player's hand
 local function draw_hand()
-  -- Use the globally tracked hovered_card_index
-  -- love.graphics.print("Hand:", 10, 400) -- Keep label on left (Keep or remove as desired)
   local hand = player_deck.hand
   local num_cards = #hand
-  local card_width = 150 
-  local card_height = 225
-  local card_spacing = 175 
-  
-  -- Calculate total width and starting position for centering
-  local total_hand_width = 0
-  if num_cards > 0 then
-    total_hand_width = card_width + (num_cards - 1) * card_spacing
-  end
-  local start_x = (love.graphics.getWidth() - total_hand_width) / 2
-  
-  -- Constants for drawing
-  local max_angle_degrees = 10 
-  local pixel_offset_per_step = 20 
-  local base_y = 420
+  local layout = get_hand_layout(num_cards)
+  local start_x = layout.start_x
+  local base_y = layout.base_y
 
-  -- 1. Draw non-hovered cards first
   for i, card in ipairs(hand) do
-    if i ~= hovered_card_index then -- Only draw if NOT hovered
-      local card_x = start_x + (i-1) * card_spacing
-      local angle_rad = DrawHelpers.calculate_card_angle(i, num_cards, max_angle_degrees)
-      local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, pixel_offset_per_step)
-      
-      DrawHelpers.draw_transformed_card(card, card_x, base_y, dy, angle_rad, card_width, card_height)
-      
-      -- Draw index number 
-      local number_x = card_x + card_width / 2 - 5 
-      local number_y = base_y + dy - 15 
-      love.graphics.print(i, number_x, number_y) 
+    if i ~= hovered_card_index then
+      local card_x = start_x + (i - 1) * HAND_UI.card_spacing
+      local angle_rad = DrawHelpers.calculate_card_angle(i, num_cards, HAND_UI.max_angle_degrees)
+      local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, HAND_UI.pixel_offset_per_step)
+
+      DrawHelpers.draw_transformed_card(card, card_x, base_y, dy, angle_rad, HAND_UI.card_width, HAND_UI.card_height)
+
+      local number_x = card_x + HAND_UI.card_width / 2 - 5
+      local number_y = base_y + dy - 15
+      love.graphics.print(i, number_x, number_y)
     end
   end
 
-  -- 2. Draw the hovered card last (if any)
   if hovered_card_index then
     local i = hovered_card_index
     local card = hand[i]
-    local card_x = start_x + (i-1) * card_spacing
-    
-    -- Original transformation values
-    local angle_rad = DrawHelpers.calculate_card_angle(i, num_cards, max_angle_degrees)
-    local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, pixel_offset_per_step)
-    
-    -- Hover effect parameters
-    local hover_scale = 1.15 -- Make it noticeably larger
-    local hover_y_offset = -40 -- Move it up significantly
+    local card_x = start_x + (i - 1) * HAND_UI.card_spacing
+    local angle_rad = DrawHelpers.calculate_card_angle(i, num_cards, HAND_UI.max_angle_degrees)
+    local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, HAND_UI.pixel_offset_per_step)
 
-    -- Use push/pop for isolation
+    local hover_scale = 1.15
+    local hover_y_offset = -40
+
     love.graphics.push()
-    
-    -- Apply transformations for hover effect:
-    -- 1. Translate to the card's final base position (including vertical offset and hover offset)
-    love.graphics.translate(card_x + card_width / 2, base_y + dy + hover_y_offset + card_height / 2)
-    -- 2. Scale
+    love.graphics.translate(card_x + HAND_UI.card_width / 2, base_y + dy + hover_y_offset + HAND_UI.card_height / 2)
     love.graphics.scale(hover_scale, hover_scale)
-    -- 3. Rotate
     love.graphics.rotate(angle_rad)
-    -- 4. Translate back by half width/height to draw from top-left corner of the *scaled* card
-    love.graphics.translate(-card_width / 2, -card_height / 2)
-    
-    -- Draw the card itself (at 0,0 because transformations handle position)
-    card:draw(0, 0) -- Assuming Card:draw draws at given x,y
-
-    love.graphics.pop() -- Restore previous graphics state
-
-    -- Draw index number for hovered card (optional, might be visually cluttered)
-    -- Position it relative to the original position for consistency
-    -- local number_x = card_x + card_width / 2 - 5 
-    -- local number_y = base_y + dy - 15 - hover_y_offset -- Adjust slightly higher due to hover
-    -- love.graphics.setColor(1,1,0) -- Maybe highlight?
-    -- love.graphics.print(i, number_x, number_y)
-    -- love.graphics.setColor(1,1,1)
+    love.graphics.translate(-HAND_UI.card_width / 2, -HAND_UI.card_height / 2)
+    card:draw(0, 0)
+    love.graphics.pop()
   end
 end
 
--- Add the update function to handle time-based changes
-function love.update(dt)
-  -- Reset hovered card each frame
-  hovered_card_index = nil
+local function draw_stats()
+  local base_x = 10
+  local base_y = 110
 
-  -- Get mouse position
-  local mx, my = love.mouse.getPosition()
+  for i, key in ipairs(STAT_ORDER) do
+    local value = terraforming_state.stats[key]
+    local target_value = terraforming_state.targets[key]
+    local distance = math.abs(value - target_value)
 
-  if gameState == 'gameplay' then
-    target:update(dt) -- Update the terraforming target (for spinning, etc.)
-    
-    -- Calculate hand layout parameters (reuse from draw_hand if possible, or recalculate)
-    local hand = player_deck.hand
-    local num_cards = #hand
-    local card_width = 150
-    local card_height = 225
-    local card_spacing = 175
-    local total_hand_width = 0
-    if num_cards > 0 then
-      total_hand_width = card_width + (num_cards - 1) * card_spacing
-    end
-    local start_x = (love.graphics.getWidth() - total_hand_width) / 2
-    local max_angle_degrees = 10 
-    local pixel_offset_per_step = 20
-    local base_y = 420
-
-    -- Check for hover, iterating backwards (top cards first)
-    for i = num_cards, 1, -1 do
-      local card = hand[i]
-      local card_x = start_x + (i-1) * card_spacing
-      local angle_rad = DrawHelpers.calculate_card_angle(i, num_cards, max_angle_degrees)
-      local dy = DrawHelpers.calculate_vertical_offset(i, num_cards, pixel_offset_per_step)
-      local current_y = base_y + dy
-
-      -- Create a rough bounding box check (ignoring rotation for simplicity first)
-      -- More accurate check would involve transforming mouse coordinates or using polygons
-      if mx >= card_x and mx <= card_x + card_width and 
-         my >= current_y and my <= current_y + card_height then
-         hovered_card_index = i
-         break -- Found the topmost hovered card
-      end
+    local color = { 0.85, 0.85, 0.85, 1 }
+    if distance <= 1 then
+      color = { 0.45, 0.9, 0.45, 1 }
+    elseif distance >= 3 then
+      color = { 0.95, 0.45, 0.45, 1 }
+    elseif distance == 2 then
+      color = { 0.95, 0.82, 0.35, 1 }
     end
 
-    -- Add other gameplay-specific updates here if needed
-  elseif gameState == 'relationships' then
-    RelationshipsView:update(dt) -- Call the relationships view update function
+    love.graphics.setColor(unpack(color))
+    love.graphics.print(
+      STAT_LABELS[key] .. ": " .. format_signed(value) .. "  (target " .. format_signed(target_value) .. ")",
+      base_x,
+      base_y + (i - 1) * 22
+    )
   end
+
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+local function draw_card_pile_widget(rect, label, count, is_hovered)
+  local base_fill = { 0.08, 0.11, 0.16, 0.95 }
+  local hover_fill = { 0.12, 0.17, 0.24, 0.95 }
+  local border = is_hovered and { 0.85, 0.92, 1.0, 1 } or { 0.55, 0.67, 0.82, 1 }
+
+  local fill = base_fill
+  if is_hovered then
+    fill = hover_fill
+  end
+
+  love.graphics.setColor(unpack(fill))
+  love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 8, 8)
+  love.graphics.setColor(unpack(border))
+  love.graphics.setLineWidth(2)
+  love.graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 8, 8)
+  love.graphics.setLineWidth(1)
+
+  local stack_w = rect.w - 46
+  local stack_h = rect.h - 72
+  local stack_x = rect.x + 23
+  local stack_y = rect.y + 34
+  for offset = 2, 0, -1 do
+    love.graphics.setColor(0.16 + offset * 0.03, 0.2 + offset * 0.03, 0.28 + offset * 0.03, 0.95)
+    love.graphics.rectangle("fill", stack_x + offset * 3, stack_y + offset * 2, stack_w, stack_h, 6, 6)
+    love.graphics.setColor(0.85, 0.88, 0.95, 0.9)
+    love.graphics.rectangle("line", stack_x + offset * 3, stack_y + offset * 2, stack_w, stack_h, 6, 6)
+  end
+
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf(label, rect.x, rect.y + 10, rect.w, "center")
+  love.graphics.printf("x" .. tostring(count), rect.x, rect.y + rect.h - 24, rect.w, "center")
+end
+
+local function draw_pile_widgets()
+  draw_card_pile_widget(get_draw_pile_rect(), "DECK", #player_deck.draw_pile, hovered_draw_pile)
+  draw_card_pile_widget(get_discard_pile_rect(), "DISCARD", #player_deck.discard_pile, hovered_discard_pile)
+end
+
+local function draw_end_turn_button()
+  local rect = get_end_turn_rect()
+  local base = { 0.2, 0.32, 0.15, 0.95 }
+  local hover = { 0.28, 0.45, 0.2, 0.98 }
+  local border = { 0.72, 0.9, 0.62, 1 }
+  local fill = hovered_end_turn and hover or base
+
+  love.graphics.setColor(unpack(fill))
+  love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 8, 8)
+  love.graphics.setColor(unpack(border))
+  love.graphics.setLineWidth(2)
+  love.graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 8, 8)
+  love.graphics.setLineWidth(1)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf("END TURN", rect.x, rect.y + 12, rect.w, "center")
+  love.graphics.printf("(E)", rect.x, rect.y + 28, rect.w, "center")
+end
+
+local function draw_hud()
+  local config = WORLD_CONFIGS[world_index]
+  local hazard = terraforming_state:get_next_hazard()
+
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.print("World " .. world_index .. "/" .. #WORLD_CONFIGS .. ": " .. config.name .. " (" .. config.tier .. ")", 10, 10)
+  love.graphics.print(
+    "Turn: " .. terraforming_state.turn .. "/" .. terraforming_state.turn_limit ..
+    "    Habitability: " .. terraforming_state.habitability .. "/" .. terraforming_state.goal,
+    10,
+    30
+  )
+  love.graphics.print("Energy: " .. current_energy .. " / " .. max_energy, 10, 50)
+  love.graphics.print("Next Hazard: " .. hazard.name .. " (" .. format_delta_list(hazard.deltas) .. ")", 10, 70)
+
+  draw_stats()
+
+  if turn_summary then
+    love.graphics.print("Last Turn Hazard: " .. turn_summary.hazard, 10, 210)
+    love.graphics.print("Hazard Delta: " .. format_delta_list(turn_summary.hazard_deltas), 10, 230)
+    love.graphics.print("Coupling Delta: " .. format_delta_list(turn_summary.coupling_deltas), 10, 250)
+    love.graphics.print(
+      "Growth " .. turn_summary.growth ..
+      " - Penalty " .. turn_summary.penalty ..
+      " = Net " .. format_signed(turn_summary.net),
+      10,
+      270
+    )
+  end
+
+  love.graphics.print("Controls: Click card or 1-9 | Click End Turn or E | R restart", 10, love.graphics.getHeight() - 22)
+end
+
+local function draw_status_overlay()
+  local width = love.graphics.getWidth()
+  local height = love.graphics.getHeight()
+  local box_w = 620
+  local box_h = 130
+  local box_x = (width - box_w) / 2
+  local box_y = 140
+
+  love.graphics.setColor(0.05, 0.05, 0.08, 0.85)
+  love.graphics.rectangle("fill", box_x, box_y, box_w, box_h, 8, 8)
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.rectangle("line", box_x, box_y, box_w, box_h, 8, 8)
+
+  if campaign_state == "world_won" then
+    love.graphics.printf("World Terraformed!", box_x, box_y + 24, box_w, "center")
+    love.graphics.printf("Press N for the next world.", box_x, box_y + 56, box_w, "center")
+  elseif campaign_state == "campaign_won" then
+    love.graphics.printf("Campaign Complete", box_x, box_y + 24, box_w, "center")
+    love.graphics.printf("You terraformed all worlds. Press R to restart.", box_x, box_y + 56, box_w, "center")
+  elseif campaign_state == "campaign_lost" then
+    love.graphics.printf("Terraforming Failed", box_x, box_y + 24, box_w, "center")
+    love.graphics.printf("Turn limit reached before habitability target. Press R to restart.", box_x, box_y + 56, box_w, "center")
+  end
+end
+
+function love.update(dt)
+  target:update(dt)
+  hovered_card_index = nil
+  hovered_draw_pile = false
+  hovered_discard_pile = false
+  hovered_end_turn = false
+
+  if campaign_state ~= "playing" then
+    return
+  end
+
+  local mx, my = love.mouse.getPosition()
+  hovered_card_index = get_card_index_at_position(mx, my)
+
+  local draw_rect = get_draw_pile_rect()
+  hovered_draw_pile = point_in_rect(mx, my, draw_rect.x, draw_rect.y, draw_rect.w, draw_rect.h)
+
+  local discard_rect = get_discard_pile_rect()
+  hovered_discard_pile = point_in_rect(mx, my, discard_rect.x, discard_rect.y, discard_rect.w, discard_rect.h)
+
+  local end_turn_rect = get_end_turn_rect()
+  hovered_end_turn = point_in_rect(mx, my, end_turn_rect.x, end_turn_rect.y, end_turn_rect.w, end_turn_rect.h)
 end
 
 function love.draw()
-  -- Note: Background drawing is now handled *within* each state block
+  Background.draw_fill()
+  Background.draw_stars()
+  target:draw()
 
-  if gameState == 'gameplay' then
-    -- Draw only the fill and stars for gameplay
-    Background.draw_fill()
-    Background.draw_stars()
+  draw_hud()
+  draw_pile_widgets()
+  draw_end_turn_button()
+  draw_hand()
 
-    -- Display Energy
-    love.graphics.print("Energy: " .. current_energy .. " / " .. max_energy, 10, 10)
-
-    -- Draw the target planet
-    target:draw()
-
-    -- Display Draw Pile and Discard Pile counts
-    love.graphics.print("Draw Pile: " .. #player_deck.draw_pile, 10, 30)
-    love.graphics.print("Discard Pile: " .. #player_deck.discard_pile, 10, 50)
-
-    -- Display Hand (using the new function)
-    draw_hand()
-
-    -- Instructions to switch view
-    love.graphics.print("Press 'v' to view System Relationships", 10, love.graphics.getHeight() - 20)
-    
-    -- Reset color after gameplay drawing
-    love.graphics.setColor(1, 1, 1, 1) 
-
-  elseif gameState == 'relationships' then
-    -- 1. Draw the solid light background color
-    local bg_color = {0.7, 0.75, 0.8, 1} -- Light Blue-Grey
-    love.graphics.setColor(unpack(bg_color))
-    love.graphics.rectangle('fill', 0, 0, love.graphics.getWidth(), love.graphics.getHeight())
-
-    -- 2. Draw *only* the clouds on top
-    Background.draw_clouds()
-
-    -- 3. Draw the relationships view
-    RelationshipsView.draw(relationship_system_instance) 
-    love.graphics.print("Press 'v' to return to Game", 10, love.graphics.getHeight() - 20)
-    
-    -- 4. Reset color to white afterwards for safety
-    love.graphics.setColor(1, 1, 1, 1) 
+  if campaign_state ~= "playing" then
+    draw_status_overlay()
   end
 end
 
 function love.keypressed(key)
-  -- State switching key
-  if key == 'v' then
-    if gameState == 'gameplay' then
-      gameState = 'relationships'
-      print("Switched to Relationships View")
-    elseif gameState == 'relationships' then
-      gameState = 'gameplay'
-      print("Switched to Gameplay View")
-    end
-    return -- Don't process other keys if we just switched state
+  if key == "r" then
+    start_campaign()
+    return
   end
 
-  -- Gameplay specific key handling
-  if gameState == 'gameplay' then
-    -- Try to play card corresponding to number keys 1-9
-    local num = tonumber(key)
-    if num and num >= 1 and num <= 9 then
-      local card_index = num
-      if card_index <= #player_deck.hand then
-        local card_to_play = player_deck.hand[card_index] -- Get card to check cost
-        local cost = card_to_play.cost or 0
-        
-        if can_afford(cost) then
-          -- Pass context including the target
-          local context = { target = target }
-          local played_card = player_deck:play_card(card_index, current_energy, context) -- Pass context
-          if played_card then
-            spend_energy(played_card.cost) -- Use cost from the actually played card
-          end
-        else
-          print("Cannot afford card " .. card_index .. " (" .. card_to_play.name .. ")")
-        end
-      else
-        print("Invalid hand index: " .. card_index)
-      end
+  if campaign_state == "world_won" then
+    if key == "n" then
+      setup_world(world_index + 1)
     end
-    
-    -- Manual energy reset for testing
-    if key == 'r' then
-      reset_energy()
-    end
-
-    -- Manual draw for testing
-    if key == 'd' then
-      player_deck:draw(1)
-    end
+    return
   end
-  
-  -- Add key handling for other states here if needed
+
+  if campaign_state ~= "playing" then
+    return
+  end
+
+  if key == "e" then
+    end_turn()
+    return
+  end
+
+  local num = tonumber(key)
+  if not num or num < 1 or num > 9 then
+    return
+  end
+
+  if num > #player_deck.hand then
+    return
+  end
+
+  try_play_card(num)
+end
+
+function love.mousepressed(x, y, button)
+  if button ~= 1 then
+    return
+  end
+
+  if campaign_state == "world_won" then
+    return
+  end
+
+  if campaign_state ~= "playing" then
+    return
+  end
+
+  local end_turn_rect = get_end_turn_rect()
+  if point_in_rect(x, y, end_turn_rect.x, end_turn_rect.y, end_turn_rect.w, end_turn_rect.h) then
+    end_turn()
+    return
+  end
+
+  local card_index = get_card_index_at_position(x, y)
+  if card_index then
+    try_play_card(card_index)
+  end
 end

--- a/terraforming_state.lua
+++ b/terraforming_state.lua
@@ -1,0 +1,281 @@
+local TerraformingState = {}
+TerraformingState.__index = TerraformingState
+
+local STAT_KEYS = { "heat", "air", "water", "soil" }
+
+local DEFAULT_TARGETS = {
+  heat = 0,
+  air = 0,
+  water = 0,
+  soil = 0
+}
+
+local DEFAULT_HAZARDS = {
+  { name = "Solar Flare", deltas = { heat = 1, air = 1 } },
+  { name = "Upper Atmos Leak", deltas = { air = -2, heat = -1 } },
+  { name = "Flash Freeze", deltas = { heat = -2, water = -1 } },
+  { name = "Dust Storm", deltas = { air = -1, soil = -1 } },
+  { name = "Melt Surge", deltas = { heat = 2, water = 1 } },
+  { name = "Acid Rain", deltas = { water = 1, soil = -2 } },
+  { name = "Spore Bloom", deltas = { soil = 2, air = 1 } },
+  { name = "Dry Front", deltas = { water = -2, soil = -1 } }
+}
+
+local function shallow_copy(input)
+  local out = {}
+  for k, v in pairs(input or {}) do
+    out[k] = v
+  end
+  return out
+end
+
+local function sign(value)
+  if value > 0 then
+    return 1
+  end
+  if value < 0 then
+    return -1
+  end
+  return 0
+end
+
+local function clamp(value, min_value, max_value)
+  if value < min_value then
+    return min_value
+  end
+  if value > max_value then
+    return max_value
+  end
+  return value
+end
+
+local function make_scaled_deltas(deltas, scale)
+  local scaled = {}
+  for key, value in pairs(deltas or {}) do
+    scaled[key] = value * scale
+  end
+  return scaled
+end
+
+local function shuffle_in_place(items)
+  for i = #items, 2, -1 do
+    local j = love.math.random(i)
+    items[i], items[j] = items[j], items[i]
+  end
+end
+
+function TerraformingState.new(config)
+  config = config or {}
+  local self = setmetatable({}, TerraformingState)
+
+  self.name = config.name or "Dustbound Expanse"
+  self.tier = config.tier or "Normal World"
+  self.min_stat = config.min_stat or -4
+  self.max_stat = config.max_stat or 4
+  self.goal = config.goal or 20
+  self.turn_limit = config.turn_limit or 10
+  self.hazard_strength = config.hazard_strength or 1
+  self.target_band = config.target_band or 1
+  self.strain_threshold = config.strain_threshold or 3
+  self.critical_threshold = config.critical_threshold or 4
+  self.coupling_threshold = config.coupling_threshold or 3
+  self.turn = 1
+  self.status = "ongoing"
+  self.habitability = 0
+  self.last_turn_summary = nil
+
+  self.targets = shallow_copy(DEFAULT_TARGETS)
+  for key, value in pairs(config.targets or {}) do
+    self.targets[key] = clamp(value, self.min_stat, self.max_stat)
+  end
+
+  self.stats = shallow_copy(DEFAULT_TARGETS)
+  for key, value in pairs(config.starting_stats or {}) do
+    self.stats[key] = clamp(value, self.min_stat, self.max_stat)
+  end
+
+  if not config.starting_stats then
+    for _, key in ipairs(STAT_KEYS) do
+      self.stats[key] = love.math.random(-2, 2)
+    end
+  end
+
+  self.hazards = {}
+  local hazard_source = config.hazards or DEFAULT_HAZARDS
+  for _, hazard in ipairs(hazard_source) do
+    table.insert(self.hazards, {
+      name = hazard.name,
+      deltas = shallow_copy(hazard.deltas)
+    })
+  end
+  shuffle_in_place(self.hazards)
+  self.hazard_index = 1
+
+  return self
+end
+
+function TerraformingState:stat_keys()
+  return STAT_KEYS
+end
+
+function TerraformingState:get_next_hazard()
+  return self.hazards[self.hazard_index]
+end
+
+function TerraformingState:advance_hazard()
+  self.hazard_index = self.hazard_index + 1
+  if self.hazard_index > #self.hazards then
+    self.hazard_index = 1
+    shuffle_in_place(self.hazards)
+  end
+end
+
+function TerraformingState:apply_stat_changes(changes, bucket)
+  local applied = {}
+  for _, key in ipairs(STAT_KEYS) do
+    local delta = (changes and changes[key]) or 0
+    if delta ~= 0 then
+      local before = self.stats[key]
+      self.stats[key] = clamp(before + delta, self.min_stat, self.max_stat)
+      local real_delta = self.stats[key] - before
+      if real_delta ~= 0 then
+        applied[key] = real_delta
+      end
+    end
+  end
+
+  if bucket then
+    for key, delta in pairs(applied) do
+      bucket[key] = (bucket[key] or 0) + delta
+    end
+  end
+
+  return applied
+end
+
+function TerraformingState:apply_player_changes(changes)
+  return self:apply_stat_changes(changes)
+end
+
+function TerraformingState:adjust_toward_targets(amount)
+  local changes = {}
+  local step = amount or 1
+  for _, key in ipairs(STAT_KEYS) do
+    local target = self.targets[key]
+    local value = self.stats[key]
+    if value < target then
+      changes[key] = step
+    elseif value > target then
+      changes[key] = -step
+    end
+  end
+  return self:apply_stat_changes(changes)
+end
+
+function TerraformingState:count_in_band()
+  local in_band = 0
+  local perfect = 0
+  local strained = 0
+  local critical = 0
+
+  for _, key in ipairs(STAT_KEYS) do
+    local distance = math.abs(self.stats[key] - self.targets[key])
+    if distance <= self.target_band then
+      in_band = in_band + 1
+    end
+    if distance == 0 then
+      perfect = perfect + 1
+    end
+    if distance >= self.strain_threshold then
+      strained = strained + 1
+    end
+    if distance >= self.critical_threshold then
+      critical = critical + 1
+    end
+  end
+
+  return in_band, perfect, strained, critical
+end
+
+function TerraformingState:build_coupling_changes(snapshot)
+  local changes = {}
+
+  local function apply_rule(source_key, target_key, factor)
+    local source_value = snapshot[source_key] or 0
+    if math.abs(source_value) >= self.coupling_threshold then
+      local delta = sign(source_value) * factor
+      changes[target_key] = (changes[target_key] or 0) + delta
+    end
+  end
+
+  apply_rule("heat", "water", -1)
+  apply_rule("heat", "soil", -1)
+  apply_rule("air", "heat", 1)
+  apply_rule("air", "water", 1)
+  apply_rule("water", "soil", 1)
+  apply_rule("water", "air", 1)
+  apply_rule("soil", "air", 1)
+
+  return changes
+end
+
+function TerraformingState:end_turn()
+  if self.status ~= "ongoing" then
+    return self.last_turn_summary
+  end
+
+  local summary = {
+    turn = self.turn,
+    hazard = nil,
+    hazard_deltas = {},
+    coupling_deltas = {},
+    in_band = 0,
+    perfect = 0,
+    strained = 0,
+    critical = 0,
+    growth = 0,
+    penalty = 0,
+    net = 0
+  }
+
+  local hazard = self:get_next_hazard()
+  summary.hazard = hazard.name
+  local scaled = make_scaled_deltas(hazard.deltas, self.hazard_strength)
+  self:apply_stat_changes(scaled, summary.hazard_deltas)
+  self:advance_hazard()
+
+  local snapshot = shallow_copy(self.stats)
+  local coupling_changes = self:build_coupling_changes(snapshot)
+  self:apply_stat_changes(coupling_changes, summary.coupling_deltas)
+
+  local in_band, perfect, strained, critical = self:count_in_band()
+  summary.in_band = in_band
+  summary.perfect = perfect
+  summary.strained = strained
+  summary.critical = critical
+
+  local growth = in_band
+  if perfect == #STAT_KEYS then
+    growth = growth + 2
+  end
+  local penalty = strained + critical
+  local net = growth - penalty
+
+  summary.growth = growth
+  summary.penalty = penalty
+  summary.net = net
+
+  self.habitability = clamp(self.habitability + net, 0, self.goal)
+  self.turn = self.turn + 1
+
+  if self.habitability >= self.goal then
+    self.status = "won"
+  elseif self.turn > self.turn_limit then
+    self.status = "lost"
+  end
+
+  self.last_turn_summary = summary
+  return summary
+end
+
+return TerraformingState


### PR DESCRIPTION
## Summary
- implement a playable 4-stat terraforming core loop (Heat/Air/Water/Soil + Habitability)
- add turn resolution with hazard application, coupling pass, and scoring
- add click-to-play cards and shared play logic for mouse + keyboard
- add explicit pile UI: deck on the left, discard on the right
- add clickable End Turn button with hover states
- add gameplay flow documentation with Mermaid in gameplay_flow.mmd and a README section

## Notes
- this is a gameplay prototype pass focused on clarity and iteration speed
- existing relationships/equation view files are left in-repo for future use but are not in the active gameplay loop