### PR TITLE
PR1: Centralize action application semantics

### DIFF
--- a/app/legacy_runtime.lua
+++ b/app/legacy_runtime.lua
@@ -11,6 +11,7 @@ local Viewport = require("viewport")
 local Worlds = require("content.worlds")
 local CouplingRules = require("content.coupling_rules")
 local PreviewContextSystem = require("systems.preview_context_system")
+local ActionApplier = require("systems.action_applier")
 
 local VIEWPORT_REF_W = 1728
 local VIEWPORT_REF_H = 798
@@ -829,23 +830,6 @@ local function end_turn()
   reset_energy()
 end
 
-local function apply_card_to_snapshot(card, snapshot, economy_state)
-  if not card then
-    return
-  end
-
-  if card.effect_fn_name == "apply_stat_changes" then
-    terraforming_state:apply_stat_changes_to(card.properties.stat_changes or {}, snapshot)
-  elseif card.effect_fn_name == "stabilize_system" then
-    terraforming_state:adjust_snapshot_toward_targets(snapshot, 1)
-  elseif card.effect_fn_name == "install_industry" then
-    local industry_def = card.properties and card.properties.industry_def
-    if industry_def and economy_state and economy_state.industries then
-      terraforming_state:install_industry_in_slots(industry_def, economy_state.industries)
-    end
-  end
-end
-
 local function get_forecast_context()
   return PreviewContextSystem.build(
     terraforming_state,
@@ -883,7 +867,7 @@ local function compute_play_recommendations(limit)
     if can_afford(card.cost or 0) then
       local snapshot = copy_stats(terraforming_state.stats)
       local economy = terraforming_state:get_economy_snapshot()
-      apply_card_to_snapshot(card, snapshot, economy)
+      ActionApplier.apply_card_preview(terraforming_state, card, snapshot, economy)
       local summary = terraforming_state:forecast_end_turn(snapshot, { economy_state = economy })
       local next_distance = math.abs(summary.projected_stats[focused_stat] - terraforming_state.targets[focused_stat])
       local focus_gain = current_distance - next_distance

--- a/systems/action_applier.lua
+++ b/systems/action_applier.lua
@@ -1,0 +1,73 @@
+local ActionApplier = {}
+
+local function is_do_nothing(action)
+  return (not action) or action.type == "do_nothing"
+end
+
+function ActionApplier.apply_card_preview(state, card, snapshot, economy_state)
+  if not card then
+    return
+  end
+
+  local effect_name = card.effect_fn_name
+  if effect_name == "apply_stat_changes" then
+    state:apply_stat_changes_to((card.properties and card.properties.stat_changes) or {}, snapshot)
+  elseif effect_name == "stabilize_system" then
+    state:adjust_snapshot_toward_targets(snapshot, 1)
+  elseif effect_name == "install_industry" then
+    local industry_def = card.properties and card.properties.industry_def
+    if industry_def and economy_state and economy_state.industries then
+      state:install_industry_in_slots(industry_def, economy_state.industries)
+    end
+  end
+end
+
+function ActionApplier.apply_action_preview(state, snapshot, economy_state, action)
+  if is_do_nothing(action) then
+    return
+  end
+
+  if action.type == "stats_delta" then
+    state:apply_stat_changes_to(action.changes or {}, snapshot)
+    return
+  end
+
+  if action.type == "card" then
+    ActionApplier.apply_card_preview(state, action.card, snapshot, economy_state)
+  end
+end
+
+function ActionApplier.apply_card_live(state, card)
+  if not card then
+    return
+  end
+
+  local effect_name = card.effect_fn_name
+  if effect_name == "apply_stat_changes" then
+    state:apply_player_changes((card.properties and card.properties.stat_changes) or {})
+  elseif effect_name == "stabilize_system" then
+    state:adjust_toward_targets(1)
+  elseif effect_name == "install_industry" then
+    local industry_def = card.properties and card.properties.industry_def
+    if industry_def then
+      state:install_industry(industry_def)
+    end
+  end
+end
+
+function ActionApplier.apply_action_live(state, action)
+  if is_do_nothing(action) then
+    return
+  end
+
+  if action.type == "stats_delta" then
+    state:apply_stat_changes(action.changes or {})
+    return
+  end
+
+  if action.type == "card" then
+    ActionApplier.apply_card_live(state, action.card)
+  end
+end
+
+return ActionApplier

--- a/systems/forecast_system.lua
+++ b/systems/forecast_system.lua
@@ -1,4 +1,5 @@
 local ForecastSystem = {}
+local ActionApplier = require("systems.action_applier")
 
 local function copy_table(input)
   local out = {}
@@ -8,44 +9,12 @@ local function copy_table(input)
   return out
 end
 
-local function apply_preview_action(state, snapshot, economy, action)
-  if not action or action.type == "do_nothing" then
-    return
-  end
-
-  if action.type == "stats_delta" then
-    state:apply_stat_changes_to(action.changes or {}, snapshot)
-    return
-  end
-
-  if action.type ~= "card" then
-    return
-  end
-
-  local card = action.card
-  if not card then
-    return
-  end
-
-  local effect_name = card.effect_fn_name
-  if effect_name == "apply_stat_changes" then
-    state:apply_stat_changes_to((card.properties and card.properties.stat_changes) or {}, snapshot)
-  elseif effect_name == "stabilize_system" then
-    state:adjust_snapshot_toward_targets(snapshot, 1)
-  elseif effect_name == "install_industry" then
-    local def = card.properties and card.properties.industry_def
-    if def then
-      state:install_industry_in_slots(def, economy.industries)
-    end
-  end
-end
-
 function ForecastSystem.preview(run_state, action)
   local state = run_state and run_state.terraforming_state or run_state
   local snapshot = copy_table(state.stats)
   local economy = state:get_economy_snapshot()
 
-  apply_preview_action(state, snapshot, economy, action)
+  ActionApplier.apply_action_preview(state, snapshot, economy, action)
 
   return state:forecast_end_turn(snapshot, {
     economy_state = economy

--- a/systems/preview_context_system.lua
+++ b/systems/preview_context_system.lua
@@ -1,4 +1,5 @@
 local PreviewContextSystem = {}
+local ActionApplier = require("systems.action_applier")
 
 local function shallow_copy(input)
   local out = {}
@@ -13,23 +14,6 @@ local function normalize_mode(mode)
     return mode
   end
   return "current"
-end
-
-local function apply_card_to_snapshot(state, card, snapshot, economy_state)
-  if not card then
-    return
-  end
-
-  if card.effect_fn_name == "apply_stat_changes" then
-    state:apply_stat_changes_to((card.properties and card.properties.stat_changes) or {}, snapshot)
-  elseif card.effect_fn_name == "stabilize_system" then
-    state:adjust_snapshot_toward_targets(snapshot, 1)
-  elseif card.effect_fn_name == "install_industry" then
-    local industry_def = card.properties and card.properties.industry_def
-    if industry_def and economy_state and economy_state.industries then
-      state:install_industry_in_slots(industry_def, economy_state.industries)
-    end
-  end
 end
 
 local function get_edges_for_snapshot(state, snapshot)
@@ -55,7 +39,7 @@ function PreviewContextSystem.build(state, hand, selected_card_index, forecast_m
     if card then
       local preview_snapshot = shallow_copy(current_snapshot)
       local preview_economy = state:get_economy_snapshot()
-      apply_card_to_snapshot(state, card, preview_snapshot, preview_economy)
+      ActionApplier.apply_card_preview(state, card, preview_snapshot, preview_economy)
       card_push_snapshot = shallow_copy(preview_snapshot)
       scenario = {
         card = card,

--- a/systems/turn_resolver.lua
+++ b/systems/turn_resolver.lua
@@ -1,40 +1,9 @@
 local TurnResolver = {}
-
-local function apply_action_to_state(state, action)
-  if not action or action.type == "do_nothing" then
-    return
-  end
-
-  if action.type == "stats_delta" then
-    state:apply_stat_changes(action.changes or {})
-    return
-  end
-
-  if action.type ~= "card" then
-    return
-  end
-
-  local card = action.card
-  if not card then
-    return
-  end
-
-  local effect_name = card.effect_fn_name
-  if effect_name == "apply_stat_changes" then
-    state:apply_player_changes((card.properties and card.properties.stat_changes) or {})
-  elseif effect_name == "stabilize_system" then
-    state:adjust_toward_targets(1)
-  elseif effect_name == "install_industry" then
-    local def = card.properties and card.properties.industry_def
-    if def then
-      state:install_industry(def)
-    end
-  end
-end
+local ActionApplier = require("systems.action_applier")
 
 function TurnResolver.resolve_end_turn(run_state, action, _rng)
   local state = run_state and run_state.terraforming_state or run_state
-  apply_action_to_state(state, action)
+  ActionApplier.apply_action_live(state, action)
   local report = state:end_turn()
   return run_state, report
 end

--- a/tests/action_applier_spec.lua
+++ b/tests/action_applier_spec.lua
@@ -1,0 +1,142 @@
+local ScenarioCases = require("tests.scenario_cases")
+local ActionApplier = require("systems.action_applier")
+local CardTypes = require("card_types")
+
+local ActionApplierSpec = {}
+
+local STATS = { "heat", "air", "water", "soil" }
+
+local function make_result()
+  return {
+    logs = {},
+    failed = 0
+  }
+end
+
+local function add_log(result, line)
+  result.logs[#result.logs + 1] = line
+end
+
+local function expect_equal(result, label, actual, expected)
+  local ok = actual == expected
+  local status = ok and "PASS" or "FAIL"
+  add_log(result, string.format("THEN %s: %s (expected %s, got %s)", status, label, tostring(expected), tostring(actual)))
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function run_preview_stats_delta_scenario()
+  local result = make_result()
+  local state = ScenarioCases.new_state()
+  local before_heat = state.stats.heat
+  local snapshot = {
+    heat = state.stats.heat,
+    air = state.stats.air,
+    water = state.stats.water,
+    soil = state.stats.soil
+  }
+  local economy = state:get_economy_snapshot()
+
+  add_log(result, "GIVEN preview snapshot copied from live stats")
+  ActionApplier.apply_action_preview(state, snapshot, economy, {
+    type = "stats_delta",
+    changes = { heat = 2, soil = -1 }
+  })
+  add_log(result, "WHEN applying preview stats_delta action")
+
+  expect_equal(result, "snapshot heat changed", snapshot.heat, state.stats.heat + 2)
+  expect_equal(result, "snapshot soil changed", snapshot.soil, state.stats.soil - 1)
+  expect_equal(result, "live state heat unchanged", state.stats.heat, before_heat)
+  return result
+end
+
+local function run_preview_install_industry_scenario()
+  local result = make_result()
+  local state = ScenarioCases.new_state()
+  local snapshot = {
+    heat = state.stats.heat,
+    air = state.stats.air,
+    water = state.stats.water,
+    soil = state.stats.soil
+  }
+  local economy = state:get_economy_snapshot()
+  local industry_card = CardTypes.createCardData("hydroponics_array")
+
+  add_log(result, "GIVEN preview economy starts with open industry slots")
+  ActionApplier.apply_action_preview(state, snapshot, economy, {
+    type = "card",
+    card = industry_card
+  })
+  add_log(result, "WHEN applying install-industry card in preview mode")
+
+  expect_equal(result, "preview economy slot 1 filled", economy.industries[1] and economy.industries[1].id, "hydroponics_array")
+  expect_equal(result, "live state slot 1 still empty", state.industries[1], nil)
+  for _, key in ipairs(STATS) do
+    expect_equal(result, "preview install does not alter stat " .. key, snapshot[key], state.stats[key])
+  end
+  return result
+end
+
+local function run_live_card_action_scenario()
+  local result = make_result()
+  local state = ScenarioCases.new_state({
+    starting_stats = { heat = -2, air = -5, water = -3, soil = -1 }
+  })
+  local before_air = state.stats.air
+  local before_heat = state.stats.heat
+  local card = CardTypes.createCardData("air_up")
+
+  add_log(result, "GIVEN live state and card Atmo Seeding (air +2)")
+  ActionApplier.apply_action_live(state, {
+    type = "card",
+    card = card
+  })
+  add_log(result, "WHEN applying live card action")
+
+  expect_equal(result, "air moved by +2", state.stats.air, before_air + 2)
+  expect_equal(result, "heat unchanged", state.stats.heat, before_heat)
+  return result
+end
+
+local function run_named_scenario(name, fn)
+  print("")
+  print("Scenario: " .. name)
+  local ok, result_or_err = pcall(fn)
+  if not ok then
+    print("  THEN FAIL: " .. tostring(result_or_err))
+    return 0, 1
+  end
+
+  for _, line in ipairs(result_or_err.logs or {}) do
+    print("  " .. line)
+  end
+
+  if (result_or_err.failed or 0) == 0 then
+    print("  RESULT: PASS")
+    return 1, 0
+  end
+
+  print("  RESULT: FAIL (" .. tostring(result_or_err.failed) .. " check(s) failed)")
+  return 0, 1
+end
+
+function ActionApplierSpec.run()
+  local scenarios = {
+    { name = "Preview stats_delta mutates snapshot only", fn = run_preview_stats_delta_scenario },
+    { name = "Preview install-industry mutates preview economy only", fn = run_preview_install_industry_scenario },
+    { name = "Live card action mutates state", fn = run_live_card_action_scenario }
+  }
+
+  local passed = 0
+  local failed = 0
+  for _, scenario in ipairs(scenarios) do
+    local scenario_passed, scenario_failed = run_named_scenario(scenario.name, scenario.fn)
+    passed = passed + scenario_passed
+    failed = failed + scenario_failed
+  end
+
+  return passed, failed
+end
+
+return ActionApplierSpec

--- a/tests/run_math_spec.lua
+++ b/tests/run_math_spec.lua
@@ -9,6 +9,7 @@ love = {
 
 local PreviewSpec = require("tests.preview_spec")
 local ForecastTraceSpec = require("tests.forecast_trace_spec")
+local ActionApplierSpec = require("tests.action_applier_spec")
 
 local function run_section(name, fn)
   print("")
@@ -28,6 +29,10 @@ failed_total = failed_total + f1
 local p2, f2 = run_section("Forecast Trace Spec", ForecastTraceSpec.run)
 passed_total = passed_total + p2
 failed_total = failed_total + f2
+
+local p3, f3 = run_section("Action Applier Spec", ActionApplierSpec.run)
+passed_total = passed_total + p3
+failed_total = failed_total + f3
 
 print("")
 print(string.format("math spec suite: %d scenario(s) passed, %d failed", passed_total, failed_total))


### PR DESCRIPTION
## Summary
This is PR 1 of post-refactor hardening (no feature expansion).

- add `systems/action_applier.lua` as the single source of truth for applying card/actions
- route preview application through shared path in:
  - `systems/forecast_system.lua`
  - `systems/preview_context_system.lua`
  - `app/legacy_runtime.lua` (preview simulation path)
- route live turn application through shared path in:
  - `systems/turn_resolver.lua`
- add plain-English test coverage for shared action semantics:
  - `tests/action_applier_spec.lua`
  - integrated into `tests/run_math_spec.lua`

## Why
Before this change, card/action semantics were duplicated across runtime/forecast/turn code paths. That increases drift risk and makes preview-vs-live parity fragile.

## Scope
Behavior-preserving refactor only:
- no new gameplay features
- no coupling/hazard rule changes
- no UI interaction changes

## Validation
- `lua tests/run_math_spec.lua`
- `lua tests/run_math_suite.lua`
- `lua tests/run_characterization.lua`
- `luac -p systems/action_applier.lua systems/forecast_system.lua systems/turn_resolver.lua systems/preview_context_system.lua app/legacy_runtime.lua tests/action_applier_spec.lua tests/run_math_spec.lua`
