### PR TITLE
Extract influence layout calculations from legacy runtime

### DIFF
--- a/app/legacy_runtime.lua
+++ b/app/legacy_runtime.lua
@@ -13,6 +13,7 @@ local CouplingRules = require("content.coupling_rules")
 local PreviewContextSystem = require("systems.preview_context_system")
 local ActionApplier = require("systems.action_applier")
 local InfluenceUIState = require("app.influence_ui_state")
+local InfluenceLayout = require("ui.layout.influence_layout")
 
 local VIEWPORT_REF_W = 1728
 local VIEWPORT_REF_H = 798
@@ -575,158 +576,27 @@ local function get_card_index_at_position(mx, my)
 end
 
 local function get_influence_layout()
-  local safe = get_safe_rect()
-  local panel_gap = 14
-  local top_y = safe.y + 76
-  local top_h = math.floor(safe.h * 0.62)
-  local map_w = math.floor(safe.w * 0.54)
-  local map_rect = {
-    x = safe.x,
-    y = top_y,
-    w = map_w,
-    h = top_h
-  }
-
-  local map_center_x = map_rect.x + math.floor(map_rect.w * 0.5)
-  local map_center_y = map_rect.y + math.floor(map_rect.h * 0.6)
-  local offset_x = math.floor(map_rect.w * 0.29)
-  local offset_y = math.floor(map_rect.h * 0.24)
-  local node_radius = math.max(48, math.floor(math.min(map_rect.w, map_rect.h) * 0.11))
-
-  local nodes = {
-    heat = { x = map_center_x, y = map_center_y - offset_y, r = node_radius },
-    water = { x = map_center_x + offset_x, y = map_center_y, r = node_radius },
-    soil = { x = map_center_x, y = map_center_y + offset_y, r = node_radius },
-    air = { x = map_center_x - offset_x, y = map_center_y, r = node_radius }
-  }
-
-  local right_x = map_rect.x + map_rect.w + panel_gap
-  local right_w = safe.x + safe.w - right_x
-  local objectives_rect = {
-    x = right_x,
-    y = map_rect.y,
-    w = right_w,
-    h = map_rect.h
-  }
-
-  local graph_explain_rect = {
-    x = map_rect.x + 22,
-    y = map_rect.y + 92,
-    w = map_rect.w - 44,
-    h = map_rect.h - 120
-  }
-
-  local turn_explain_rect = {
-    x = safe.x + 12,
-    y = map_rect.y + 92,
-    w = safe.w - 24,
-    h = map_rect.h - 82
-  }
-
-  local cards_y = map_rect.y + map_rect.h + 12
-  local cards_rect = {
-    x = safe.x,
-    y = cards_y,
-    w = safe.w,
-    h = (safe.y + safe.h) - cards_y
-  }
-
-  return {
-    map_rect = map_rect,
-    nodes = nodes,
-    objectives_rect = objectives_rect,
-    graph_explain_rect = graph_explain_rect,
-    turn_explain_rect = turn_explain_rect,
-    cards_rect = cards_rect
-  }
+  return InfluenceLayout.compute(get_safe_rect())
 end
 
 local function get_map_toggle_buttons(layout)
-  local map_rect = layout.map_rect
-  local button_h = 26
-  local filter_w = 198
-  local right = map_rect.x + map_rect.w - 12
-  local filter_x = right - filter_w
-  local y = map_rect.y + 8
-  local explain_w = 154
-  local explain_y = map_rect.y + map_rect.h - button_h - 8
-
-  return {
-    filter = { x = filter_x, y = y, w = filter_w, h = button_h },
-    explain_graph = { x = map_rect.x + 12, y = explain_y, w = explain_w, h = button_h }
-  }
+  return InfluenceLayout.get_map_toggle_buttons(layout)
 end
 
 local function get_forecast_mode_buttons(rect)
-  return {
-    {
-      id = "current",
-      text = "Current",
-      x = rect.x + 14,
-      y = rect.y + 108,
-      w = 168,
-      h = 24
-    }
-  }
+  return InfluenceLayout.get_forecast_mode_buttons(rect)
 end
 
 local function get_preview_explain_button(layout)
-  local rect = layout.cards_rect
-  return {
-    x = rect.x + 12,
-    y = rect.y + rect.h - 30,
-    w = 176,
-    h = 24
-  }
+  return InfluenceLayout.get_preview_explain_button(layout)
 end
 
 local function get_objectives_explain_button(layout)
-  local rect = layout.objectives_rect
-  return {
-    x = rect.x + 14,
-    y = rect.y + rect.h - 34,
-    w = 188,
-    h = 24
-  }
+  return InfluenceLayout.get_objectives_explain_button(layout)
 end
 
 local function get_influence_card_rects(layout)
-  local rows = {}
-  local options = {
-    { kind = "do_nothing" }
-  }
-  for i, card in ipairs(player_deck.hand) do
-    table.insert(options, { kind = "card", card = card, card_index = i })
-  end
-  local rect = layout.cards_rect
-  local card_w = 170
-  local card_h = 58
-  local gap_x = 12
-  local gap_y = 10
-  local footer_reserved = 42
-  local cards_per_row = math.max(1, math.floor((rect.w - 20 + gap_x) / (card_w + gap_x)))
-  local max_rows = math.max(1, math.floor((rect.h - 34 - footer_reserved + gap_y) / (card_h + gap_y)))
-  local used_width = cards_per_row * card_w + (cards_per_row - 1) * gap_x
-  local start_x = rect.x + math.floor((rect.w - used_width) / 2)
-
-  for i, option in ipairs(options) do
-    local row = math.floor((i - 1) / cards_per_row)
-    if row >= max_rows then
-      break
-    end
-    local col = (i - 1) % cards_per_row
-    local x = start_x + col * (card_w + gap_x)
-    local y = rect.y + 34 + row * (card_h + gap_y)
-    rows[i] = {
-      x = x,
-      y = y,
-      w = card_w,
-      h = card_h,
-      option = option
-    }
-  end
-
-  return rows
+  return InfluenceLayout.get_card_rects(layout, player_deck.hand)
 end
 
 local function setup_world(index)

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -1,0 +1,134 @@
+local InfluenceLayout = require("ui.layout.influence_layout")
+
+local InfluenceLayoutSpec = {}
+
+local function make_result()
+  return {
+    logs = {},
+    failed = 0
+  }
+end
+
+local function add_log(result, line)
+  result.logs[#result.logs + 1] = line
+end
+
+local function expect_equal(result, label, actual, expected)
+  local ok = actual == expected
+  local status = ok and "PASS" or "FAIL"
+  add_log(result, string.format("THEN %s: %s (expected %s, got %s)", status, label, tostring(expected), tostring(actual)))
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function run_compute_contract()
+  local result = make_result()
+  local safe = { x = 96, y = 20, w = 1536, h = 758 }
+
+  add_log(result, "GIVEN a mobile safe rect")
+  local layout = InfluenceLayout.compute(safe)
+  add_log(result, "WHEN computing influence layout panels and nodes")
+
+  expect_equal(result, "map x", layout.map_rect.x, safe.x)
+  expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 76)
+  expect_equal(result, "map width ratio", layout.map_rect.w, math.floor(safe.w * 0.54))
+  expect_equal(result, "map height ratio", layout.map_rect.h, math.floor(safe.h * 0.62))
+
+  local right_x = layout.map_rect.x + layout.map_rect.w + 14
+  expect_equal(result, "objectives x follows map + gap", layout.objectives_rect.x, right_x)
+  expect_equal(result, "objectives width fills remaining space", layout.objectives_rect.w, safe.x + safe.w - right_x)
+  expect_equal(result, "cards span full safe width", layout.cards_rect.w, safe.w)
+  expect_equal(result, "cards start below map panel", layout.cards_rect.y, layout.map_rect.y + layout.map_rect.h + 12)
+
+  expect_equal(result, "heat and soil share x", layout.nodes.heat.x, layout.nodes.soil.x)
+  expect_equal(result, "air and water share y", layout.nodes.air.y, layout.nodes.water.y)
+  expect_equal(result, "all nodes share radius", layout.nodes.heat.r, layout.nodes.air.r)
+  return result
+end
+
+local function run_controls_contract()
+  local result = make_result()
+  local layout = InfluenceLayout.compute({ x = 0, y = 0, w = 1728, h = 798 })
+
+  add_log(result, "GIVEN computed influence layout")
+  local toggles = InfluenceLayout.get_map_toggle_buttons(layout)
+  local mode_buttons = InfluenceLayout.get_forecast_mode_buttons(layout.turn_explain_rect)
+  local preview_button = InfluenceLayout.get_preview_explain_button(layout)
+  local objectives_button = InfluenceLayout.get_objectives_explain_button(layout)
+  add_log(result, "WHEN resolving button geometry")
+
+  expect_equal(result, "map filter button width", toggles.filter.w, 198)
+  expect_equal(result, "map explain button width", toggles.explain_graph.w, 154)
+  expect_equal(result, "single forecast mode button currently available", #mode_buttons, 1)
+  expect_equal(result, "forecast button id", mode_buttons[1].id, "current")
+  expect_equal(result, "preview explain button width", preview_button.w, 176)
+  expect_equal(result, "objectives explain button width", objectives_button.w, 188)
+  return result
+end
+
+local function run_card_rects_contract()
+  local result = make_result()
+  local layout = InfluenceLayout.compute({ x = 0, y = 0, w = 1728, h = 798 })
+  local hand = {
+    { name = "Card A" },
+    { name = "Card B" },
+    { name = "Card C" },
+    { name = "Card D" },
+    { name = "Card E" }
+  }
+
+  add_log(result, "GIVEN five hand cards for influence preview selector")
+  local card_rects = InfluenceLayout.get_card_rects(layout, hand)
+  add_log(result, "WHEN generating card rect options")
+
+  expect_equal(result, "do-nothing + five cards", #card_rects, 6)
+  expect_equal(result, "first option is do-nothing", card_rects[1].option.kind, "do_nothing")
+  expect_equal(result, "second option is first hand card", card_rects[2].option.card_index, 1)
+  expect_equal(result, "last option is fifth hand card", card_rects[6].option.card_index, 5)
+  expect_equal(result, "card width preserved", card_rects[1].w, 170)
+  expect_equal(result, "card height preserved", card_rects[1].h, 58)
+  return result
+end
+
+local function run_named_scenario(name, fn)
+  print("")
+  print("Scenario: " .. name)
+  local ok, result_or_err = pcall(fn)
+  if not ok then
+    print("  THEN FAIL: " .. tostring(result_or_err))
+    return 0, 1
+  end
+
+  for _, line in ipairs(result_or_err.logs or {}) do
+    print("  " .. line)
+  end
+
+  if (result_or_err.failed or 0) == 0 then
+    print("  RESULT: PASS")
+    return 1, 0
+  end
+
+  print("  RESULT: FAIL (" .. tostring(result_or_err.failed) .. " check(s) failed)")
+  return 0, 1
+end
+
+function InfluenceLayoutSpec.run()
+  local scenarios = {
+    { name = "Influence Panel Compute Contract", fn = run_compute_contract },
+    { name = "Influence Button Geometry Contract", fn = run_controls_contract },
+    { name = "Influence Card Rects Contract", fn = run_card_rects_contract }
+  }
+
+  local passed = 0
+  local failed = 0
+  for _, scenario in ipairs(scenarios) do
+    local scenario_passed, scenario_failed = run_named_scenario(scenario.name, scenario.fn)
+    passed = passed + scenario_passed
+    failed = failed + scenario_failed
+  end
+
+  return passed, failed
+end
+
+return InfluenceLayoutSpec

--- a/tests/run_math_spec.lua
+++ b/tests/run_math_spec.lua
@@ -11,6 +11,7 @@ local PreviewSpec = require("tests.preview_spec")
 local ForecastTraceSpec = require("tests.forecast_trace_spec")
 local ActionApplierSpec = require("tests.action_applier_spec")
 local InfluenceUIStateSpec = require("tests.influence_ui_state_spec")
+local InfluenceLayoutSpec = require("tests.influence_layout_spec")
 
 local function run_section(name, fn)
   print("")
@@ -38,6 +39,10 @@ failed_total = failed_total + f3
 local p4, f4 = run_section("Influence UI State Spec", InfluenceUIStateSpec.run)
 passed_total = passed_total + p4
 failed_total = failed_total + f4
+
+local p5, f5 = run_section("Influence Layout Spec", InfluenceLayoutSpec.run)
+passed_total = passed_total + p5
+failed_total = failed_total + f5
 
 print("")
 print(string.format("math spec suite: %d scenario(s) passed, %d failed", passed_total, failed_total))

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -2,36 +2,157 @@ local InfluenceLayout = {}
 
 function InfluenceLayout.compute(safe_rect)
   local safe = safe_rect
-  local top_h = math.floor(safe.h * 0.67)
-  local graph_w = math.floor(safe.w * 0.54)
-  local gap = 16
-
-  local graph_rect = {
+  local panel_gap = 14
+  local top_y = safe.y + 76
+  local top_h = math.floor(safe.h * 0.62)
+  local map_w = math.floor(safe.w * 0.54)
+  local map_rect = {
     x = safe.x,
-    y = safe.y,
-    w = graph_w,
+    y = top_y,
+    w = map_w,
     h = top_h
   }
 
+  local map_center_x = map_rect.x + math.floor(map_rect.w * 0.5)
+  local map_center_y = map_rect.y + math.floor(map_rect.h * 0.6)
+  local offset_x = math.floor(map_rect.w * 0.29)
+  local offset_y = math.floor(map_rect.h * 0.24)
+  local node_radius = math.max(48, math.floor(math.min(map_rect.w, map_rect.h) * 0.11))
+  local nodes = {
+    heat = { x = map_center_x, y = map_center_y - offset_y, r = node_radius },
+    water = { x = map_center_x + offset_x, y = map_center_y, r = node_radius },
+    soil = { x = map_center_x, y = map_center_y + offset_y, r = node_radius },
+    air = { x = map_center_x - offset_x, y = map_center_y, r = node_radius }
+  }
+
+  local right_x = map_rect.x + map_rect.w + panel_gap
+  local right_w = safe.x + safe.w - right_x
   local objectives_rect = {
-    x = graph_rect.x + graph_rect.w + gap,
-    y = safe.y,
-    w = safe.w - graph_rect.w - gap,
+    x = right_x,
+    y = map_rect.y,
+    w = right_w,
     h = top_h
   }
 
-  local preview_rect = {
+  local graph_explain_rect = {
+    x = map_rect.x + 22,
+    y = map_rect.y + 92,
+    w = map_rect.w - 44,
+    h = map_rect.h - 120
+  }
+
+  local turn_explain_rect = {
+    x = safe.x + 12,
+    y = map_rect.y + 92,
+    w = safe.w - 24,
+    h = map_rect.h - 82
+  }
+
+  local cards_y = map_rect.y + map_rect.h + 12
+  local cards_rect = {
     x = safe.x,
-    y = safe.y + top_h + gap,
+    y = cards_y,
     w = safe.w,
-    h = safe.h - top_h - gap
+    h = (safe.y + safe.h) - cards_y
   }
 
   return {
-    graph_rect = graph_rect,
+    map_rect = map_rect,
+    nodes = nodes,
     objectives_rect = objectives_rect,
-    preview_rect = preview_rect
+    graph_explain_rect = graph_explain_rect,
+    turn_explain_rect = turn_explain_rect,
+    cards_rect = cards_rect
   }
+end
+
+function InfluenceLayout.get_map_toggle_buttons(layout)
+  local map_rect = layout.map_rect
+  local button_h = 26
+  local filter_w = 198
+  local right = map_rect.x + map_rect.w - 12
+  local filter_x = right - filter_w
+  local y = map_rect.y + 8
+  local explain_w = 154
+  local explain_y = map_rect.y + map_rect.h - button_h - 8
+
+  return {
+    filter = { x = filter_x, y = y, w = filter_w, h = button_h },
+    explain_graph = { x = map_rect.x + 12, y = explain_y, w = explain_w, h = button_h }
+  }
+end
+
+function InfluenceLayout.get_forecast_mode_buttons(rect)
+  return {
+    {
+      id = "current",
+      text = "Current",
+      x = rect.x + 14,
+      y = rect.y + 108,
+      w = 168,
+      h = 24
+    }
+  }
+end
+
+function InfluenceLayout.get_preview_explain_button(layout)
+  local rect = layout.cards_rect
+  return {
+    x = rect.x + 12,
+    y = rect.y + rect.h - 30,
+    w = 176,
+    h = 24
+  }
+end
+
+function InfluenceLayout.get_objectives_explain_button(layout)
+  local rect = layout.objectives_rect
+  return {
+    x = rect.x + 14,
+    y = rect.y + rect.h - 34,
+    w = 188,
+    h = 24
+  }
+end
+
+function InfluenceLayout.get_card_rects(layout, hand)
+  local rows = {}
+  local options = {
+    { kind = "do_nothing" }
+  }
+  for i, card in ipairs(hand or {}) do
+    table.insert(options, { kind = "card", card = card, card_index = i })
+  end
+
+  local rect = layout.cards_rect
+  local card_w = 170
+  local card_h = 58
+  local gap_x = 12
+  local gap_y = 10
+  local footer_reserved = 42
+  local cards_per_row = math.max(1, math.floor((rect.w - 20 + gap_x) / (card_w + gap_x)))
+  local max_rows = math.max(1, math.floor((rect.h - 34 - footer_reserved + gap_y) / (card_h + gap_y)))
+  local used_width = cards_per_row * card_w + (cards_per_row - 1) * gap_x
+  local start_x = rect.x + math.floor((rect.w - used_width) / 2)
+
+  for i, option in ipairs(options) do
+    local row = math.floor((i - 1) / cards_per_row)
+    if row >= max_rows then
+      break
+    end
+    local col = (i - 1) % cards_per_row
+    local x = start_x + col * (card_w + gap_x)
+    local y = rect.y + 34 + row * (card_h + gap_y)
+    rows[i] = {
+      x = x,
+      y = y,
+      w = card_w,
+      h = card_h,
+      option = option
+    }
+  end
+
+  return rows
 end
 
 return InfluenceLayout


### PR DESCRIPTION
## Summary
- extract influence-screen layout calculations from `app/legacy_runtime.lua` into `ui/layout/influence_layout.lua`
- keep runtime behavior unchanged by routing existing runtime helper calls to the layout module
- add explicit layout contract tests for panel geometry, button geometry, and preview card rect generation

## What moved
`ui/layout/influence_layout.lua` now owns:
- panel + node geometry (`compute`)
- map toggle button geometry (`get_map_toggle_buttons`)
- forecast mode button geometry (`get_forecast_mode_buttons`)
- explain button geometry (`get_preview_explain_button`, `get_objectives_explain_button`)
- preview selector card option rects (`get_card_rects`)

`app/legacy_runtime.lua` now:
- requires `ui.layout.influence_layout`
- delegates the former local layout helpers to the layout module
- keeps all rendering and interaction logic unchanged

## Tests
- added `tests/influence_layout_spec.lua` (plain-English Given/When/Then checks)
- registered in `tests/run_math_spec.lua`

Commands run:
- `luac -p app/legacy_runtime.lua ui/layout/influence_layout.lua tests/influence_layout_spec.lua tests/run_math_spec.lua`
- `lua tests/run_math_spec.lua`
- `lua tests/run_math_suite.lua`
- `lua tests/run_characterization.lua`
