### PR TITLE
Extract gameplay layout geometry from legacy runtime

### DIFF
--- a/app/legacy_runtime.lua
+++ b/app/legacy_runtime.lua
@@ -14,6 +14,7 @@ local PreviewContextSystem = require("systems.preview_context_system")
 local ActionApplier = require("systems.action_applier")
 local InfluenceUIState = require("app.influence_ui_state")
 local InfluenceLayout = require("ui.layout.influence_layout")
+local GameplayLayout = require("ui.layout.gameplay_layout")
 
 local VIEWPORT_REF_W = 1728
 local VIEWPORT_REF_H = 798
@@ -260,10 +261,10 @@ local function update_target_layout()
   if not target then
     return
   end
-  local safe = get_safe_rect()
-  target.x = safe.x + (safe.w * 0.72)
-  target.y = safe.y + (safe.h * 0.34)
-  target.radius = math.floor(math.min(safe.w, safe.h) * 0.28)
+  local planet = GameplayLayout.get_planet(get_safe_rect())
+  target.x = planet.x
+  target.y = planet.y
+  target.radius = planet.radius
 end
 
 local function point_in_rect(px, py, rx, ry, rw, rh)
@@ -406,24 +407,11 @@ local function get_hazard_origin_color(origin)
 end
 
 local function get_hazard_card_rect()
-  local safe = get_safe_rect()
-  local card_w = 132
-  local card_h = 170
-  local desired_x = target.x - target.radius - card_w - 24
-  local min_x = safe.x + 16
-  local max_x = safe.x + safe.w - card_w - 16
-  local x = clamp_value(desired_x, min_x, max_x)
-  local y = clamp_value(
-    target.y - math.floor(card_h * 0.36),
-    safe.y + 16,
-    safe.y + safe.h - card_h - 16
-  )
-  return {
-    x = x,
-    y = y,
-    w = card_w,
-    h = card_h
-  }
+  return GameplayLayout.get_hazard_card_rect(get_safe_rect(), {
+    x = target.x,
+    y = target.y,
+    radius = target.radius
+  })
 end
 
 local function draw_next_hazard_card()
@@ -512,49 +500,20 @@ local function edge_is_visible(edge)
 end
 
 local function get_hand_layout(num_cards)
-  local safe = get_safe_rect()
-  local total_hand_width = 0
-  if num_cards > 0 then
-    total_hand_width = HAND_UI.card_width + (num_cards - 1) * HAND_UI.card_spacing
-  end
-  local start_x = safe.x + ((safe.w - total_hand_width) * 0.5)
-  local base_y = safe.y + safe.h - HAND_UI.card_height - 24
-  return { start_x = start_x, base_y = base_y }
+  return GameplayLayout.get_hand_layout(get_safe_rect(), num_cards, HAND_UI)
 end
 
 local function get_draw_pile_rect()
-  local safe = get_safe_rect()
-  local y = safe.y + safe.h - PILE_UI.height - 12
-  return {
-    x = safe.x + 16,
-    y = y,
-    w = PILE_UI.width,
-    h = PILE_UI.height
-  }
+  return GameplayLayout.get_deck_rect(get_safe_rect(), PILE_UI)
 end
 
 local function get_discard_pile_rect()
-  local safe = get_safe_rect()
-  local y = safe.y + safe.h - PILE_UI.height - 12
-  return {
-    x = safe.x + safe.w - PILE_UI.width - 16,
-    y = y,
-    w = PILE_UI.width,
-    h = PILE_UI.height
-  }
+  return GameplayLayout.get_discard_rect(get_safe_rect(), PILE_UI)
 end
 
 local function get_end_turn_rect()
-  local safe = get_safe_rect()
   local hand_layout = get_hand_layout(#player_deck.hand)
-  local y = hand_layout.base_y + math.floor((HAND_UI.card_height - END_TURN_UI.height) * 0.5)
-  y = clamp_value(y, safe.y + 14, safe.y + safe.h - END_TURN_UI.height - 14)
-  return {
-    x = safe.x + safe.w - END_TURN_UI.width - 16,
-    y = y,
-    w = END_TURN_UI.width,
-    h = END_TURN_UI.height
-  }
+  return GameplayLayout.get_end_turn_rect(get_safe_rect(), hand_layout, HAND_UI, END_TURN_UI)
 end
 
 local function get_card_index_at_position(mx, my)

--- a/tests/gameplay_layout_spec.lua
+++ b/tests/gameplay_layout_spec.lua
@@ -1,0 +1,160 @@
+local GameplayLayout = require("ui.layout.gameplay_layout")
+
+local GameplayLayoutSpec = {}
+
+local function make_result()
+  return {
+    logs = {},
+    failed = 0
+  }
+end
+
+local function add_log(result, line)
+  result.logs[#result.logs + 1] = line
+end
+
+local function expect_equal(result, label, actual, expected)
+  local ok = actual == expected
+  local status = ok and "PASS" or "FAIL"
+  add_log(result, string.format("THEN %s: %s (expected %s, got %s)", status, label, tostring(expected), tostring(actual)))
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function expect_near(result, label, actual, expected, epsilon)
+  local gap = math.abs((actual or 0) - expected)
+  local ok = gap <= (epsilon or 0.0001)
+  local status = ok and "PASS" or "FAIL"
+  add_log(
+    result,
+    string.format("THEN %s: %s (expected %.4f, got %.4f, |delta|=%.6f)", status, label, expected, actual or 0, gap)
+  )
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function run_baseline_geometry_contract()
+  local result = make_result()
+  local safe = { x = 96, y = 20, w = 1536, h = 758 }
+  local hand_ui = { card_width = 150, card_height = 225, card_spacing = 175 }
+  local pile_ui = { width = 90, height = 120 }
+  local end_turn_ui = { width = 170, height = 50 }
+
+  add_log(result, "GIVEN baseline mobile safe rect and gameplay UI constants")
+  local planet = GameplayLayout.get_planet(safe)
+  local hand = GameplayLayout.get_hand_layout(safe, 5, hand_ui)
+  local deck = GameplayLayout.get_deck_rect(safe, pile_ui)
+  local discard = GameplayLayout.get_discard_rect(safe, pile_ui)
+  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, hand_ui, end_turn_ui)
+  local hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
+  add_log(result, "WHEN computing gameplay positions")
+
+  expect_near(result, "planet x", planet.x, safe.x + (safe.w * 0.72))
+  expect_near(result, "planet y", planet.y, safe.y + (safe.h * 0.34))
+  expect_equal(result, "planet radius", planet.radius, math.floor(math.min(safe.w, safe.h) * 0.28))
+
+  expect_near(result, "hand start x", hand.start_x, 439.0)
+  expect_near(result, "hand base y", hand.base_y, 529.0)
+
+  expect_equal(result, "deck x", deck.x, 112)
+  expect_equal(result, "deck y", deck.y, 646)
+  expect_equal(result, "discard x", discard.x, 1526)
+  expect_equal(result, "discard y", discard.y, 646)
+  expect_equal(result, "end turn x", end_turn.x, 1446)
+  expect_equal(result, "end turn y", end_turn.y, 616)
+
+  expect_near(result, "hazard x", hazard.x, 833.92, 0.001)
+  expect_near(result, "hazard y", hazard.y, 216.72, 0.001)
+  expect_equal(result, "hazard width", hazard.w, 132)
+  expect_equal(result, "hazard height", hazard.h, 170)
+  return result
+end
+
+local function run_hazard_clamp_contract()
+  local result = make_result()
+  local safe = { x = 0, y = 0, w = 420, h = 260 }
+  local planet = { x = 120, y = 230, radius = 100 }
+
+  add_log(result, "GIVEN a small safe rect where incoming hazard card would overflow")
+  local hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
+  add_log(result, "WHEN hazard rect is clamped inside safe bounds")
+
+  expect_equal(result, "hazard x clamps to min inset", hazard.x, 16)
+  expect_equal(result, "hazard y clamps to max inset", hazard.y, 74)
+  expect_equal(result, "hazard width fixed", hazard.w, 132)
+  expect_equal(result, "hazard height fixed", hazard.h, 170)
+  return result
+end
+
+local function run_compute_parity_contract()
+  local result = make_result()
+  local safe = { x = 96, y = 20, w = 1536, h = 758 }
+  local ui_state = {
+    hand_count = 5,
+    hand_ui = { card_width = 150, card_height = 225, card_spacing = 175 },
+    pile_ui = { width = 90, height = 120 },
+    end_turn_ui = { width = 170, height = 50 }
+  }
+
+  add_log(result, "GIVEN full gameplay layout compute inputs")
+  local combined = GameplayLayout.compute(safe, ui_state)
+  local planet = GameplayLayout.get_planet(safe)
+  local hand = GameplayLayout.get_hand_layout(safe, ui_state.hand_count, ui_state.hand_ui)
+  local deck = GameplayLayout.get_deck_rect(safe, ui_state.pile_ui)
+  local discard = GameplayLayout.get_discard_rect(safe, ui_state.pile_ui)
+  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, ui_state.hand_ui, ui_state.end_turn_ui)
+  local hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
+  add_log(result, "WHEN comparing compute output to helper outputs")
+
+  expect_near(result, "compute planet x parity", combined.planet.x, planet.x)
+  expect_near(result, "compute hand start x parity", combined.hand.start_x, hand.start_x)
+  expect_equal(result, "compute deck x parity", combined.deck.x, deck.x)
+  expect_equal(result, "compute discard x parity", combined.discard.x, discard.x)
+  expect_equal(result, "compute end-turn y parity", combined.end_turn.y, end_turn.y)
+  expect_near(result, "compute hazard x parity", combined.incoming_hazard.x, hazard.x, 0.001)
+  return result
+end
+
+local function run_named_scenario(name, fn)
+  print("")
+  print("Scenario: " .. name)
+  local ok, result_or_err = pcall(fn)
+  if not ok then
+    print("  THEN FAIL: " .. tostring(result_or_err))
+    return 0, 1
+  end
+
+  for _, line in ipairs(result_or_err.logs or {}) do
+    print("  " .. line)
+  end
+
+  if (result_or_err.failed or 0) == 0 then
+    print("  RESULT: PASS")
+    return 1, 0
+  end
+
+  print("  RESULT: FAIL (" .. tostring(result_or_err.failed) .. " check(s) failed)")
+  return 0, 1
+end
+
+function GameplayLayoutSpec.run()
+  local scenarios = {
+    { name = "Gameplay Baseline Geometry Contract", fn = run_baseline_geometry_contract },
+    { name = "Gameplay Hazard Clamp Contract", fn = run_hazard_clamp_contract },
+    { name = "Gameplay Compute Helper Parity Contract", fn = run_compute_parity_contract }
+  }
+
+  local passed = 0
+  local failed = 0
+  for _, scenario in ipairs(scenarios) do
+    local scenario_passed, scenario_failed = run_named_scenario(scenario.name, scenario.fn)
+    passed = passed + scenario_passed
+    failed = failed + scenario_failed
+  end
+
+  return passed, failed
+end
+
+return GameplayLayoutSpec

--- a/tests/run_math_spec.lua
+++ b/tests/run_math_spec.lua
@@ -12,6 +12,7 @@ local ForecastTraceSpec = require("tests.forecast_trace_spec")
 local ActionApplierSpec = require("tests.action_applier_spec")
 local InfluenceUIStateSpec = require("tests.influence_ui_state_spec")
 local InfluenceLayoutSpec = require("tests.influence_layout_spec")
+local GameplayLayoutSpec = require("tests.gameplay_layout_spec")
 
 local function run_section(name, fn)
   print("")
@@ -43,6 +44,10 @@ failed_total = failed_total + f4
 local p5, f5 = run_section("Influence Layout Spec", InfluenceLayoutSpec.run)
 passed_total = passed_total + p5
 failed_total = failed_total + f5
+
+local p6, f6 = run_section("Gameplay Layout Spec", GameplayLayoutSpec.run)
+passed_total = passed_total + p6
+failed_total = failed_total + f6
 
 print("")
 print(string.format("math spec suite: %d scenario(s) passed, %d failed", passed_total, failed_total))

--- a/ui/layout/gameplay_layout.lua
+++ b/ui/layout/gameplay_layout.lua
@@ -1,47 +1,122 @@
 local GameplayLayout = {}
 
+local function clamp_value(value, min_value, max_value)
+  if value < min_value then
+    return min_value
+  end
+  if value > max_value then
+    return max_value
+  end
+  return value
+end
+
+function GameplayLayout.get_planet(safe_rect)
+  local safe = safe_rect
+  return {
+    x = safe.x + (safe.w * 0.72),
+    y = safe.y + (safe.h * 0.34),
+    radius = math.floor(math.min(safe.w, safe.h) * 0.28)
+  }
+end
+
+function GameplayLayout.get_hand_layout(safe_rect, num_cards, hand_ui)
+  local safe = safe_rect
+  local hand = hand_ui or {}
+  local card_width = hand.card_width or 150
+  local card_height = hand.card_height or 225
+  local card_spacing = hand.card_spacing or 175
+  local total_hand_width = 0
+  if num_cards and num_cards > 0 then
+    total_hand_width = card_width + (num_cards - 1) * card_spacing
+  end
+  return {
+    start_x = safe.x + ((safe.w - total_hand_width) * 0.5),
+    base_y = safe.y + safe.h - card_height - 24
+  }
+end
+
+function GameplayLayout.get_deck_rect(safe_rect, pile_ui)
+  local safe = safe_rect
+  local pile = pile_ui or {}
+  local w = pile.width or 90
+  local h = pile.height or 120
+  local y = safe.y + safe.h - h - 12
+  return {
+    x = safe.x + 16,
+    y = y,
+    w = w,
+    h = h
+  }
+end
+
+function GameplayLayout.get_discard_rect(safe_rect, pile_ui)
+  local safe = safe_rect
+  local pile = pile_ui or {}
+  local w = pile.width or 90
+  local h = pile.height or 120
+  local y = safe.y + safe.h - h - 12
+  return {
+    x = safe.x + safe.w - w - 16,
+    y = y,
+    w = w,
+    h = h
+  }
+end
+
+function GameplayLayout.get_end_turn_rect(safe_rect, hand_layout, hand_ui, end_turn_ui)
+  local safe = safe_rect
+  local hand = hand_ui or {}
+  local end_turn = end_turn_ui or {}
+  local h = end_turn.height or 50
+  local w = end_turn.width or 170
+  local card_h = hand.card_height or 225
+  local y = hand_layout.base_y + math.floor((card_h - h) * 0.5)
+  y = clamp_value(y, safe.y + 14, safe.y + safe.h - h - 14)
+  return {
+    x = safe.x + safe.w - w - 16,
+    y = y,
+    w = w,
+    h = h
+  }
+end
+
+function GameplayLayout.get_hazard_card_rect(safe_rect, planet)
+  local safe = safe_rect
+  local card_w = 132
+  local card_h = 170
+  local desired_x = planet.x - planet.radius - card_w - 24
+  local min_x = safe.x + 16
+  local max_x = safe.x + safe.w - card_w - 16
+  local x = clamp_value(desired_x, min_x, max_x)
+  local y = clamp_value(
+    planet.y - math.floor(card_h * 0.36),
+    safe.y + 16,
+    safe.y + safe.h - card_h - 16
+  )
+  return {
+    x = x,
+    y = y,
+    w = card_w,
+    h = card_h
+  }
+end
+
 function GameplayLayout.compute(safe_rect, ui_state)
   local safe = safe_rect
-  local card_w = ((ui_state and ui_state.hand_ui and ui_state.hand_ui.card_width) or 150)
-  local card_h = ((ui_state and ui_state.hand_ui and ui_state.hand_ui.card_height) or 225)
-  local hand_y = safe.y + safe.h - card_h - 12
-
-  local deck_w = 88
-  local deck_h = 118
+  local hand = (ui_state and ui_state.hand_ui) or nil
+  local pile = (ui_state and ui_state.pile_ui) or nil
+  local end_turn = (ui_state and ui_state.end_turn_ui) or nil
+  local hand_count = (ui_state and ui_state.hand_count) or 0
+  local planet = GameplayLayout.get_planet(safe)
+  local hand_layout = GameplayLayout.get_hand_layout(safe, hand_count, hand)
 
   return {
-    planet = {
-      x = safe.x + safe.w * 0.72,
-      y = safe.y + safe.h * 0.34,
-      radius = math.floor(math.min(safe.w, safe.h) * 0.28)
-    },
-    hand = {
-      baseline_y = hand_y
-    },
-    deck = {
-      x = safe.x + 8,
-      y = hand_y - deck_h - 24,
-      w = deck_w,
-      h = deck_h
-    },
-    discard = {
-      x = safe.x + safe.w - deck_w - 8,
-      y = hand_y - deck_h - 24,
-      w = deck_w,
-      h = deck_h
-    },
-    end_turn = {
-      w = 170,
-      h = 50,
-      x = safe.x + safe.w - 186,
-      y = hand_y + card_h - 58
-    },
-    incoming_hazard = {
-      x = safe.x + safe.w * 0.53,
-      y = safe.y + safe.h * 0.25,
-      w = 140,
-      h = 180
-    }
+    planet = planet,
+    hand = hand_layout,
+    deck = GameplayLayout.get_deck_rect(safe, pile),
+    discard = GameplayLayout.get_discard_rect(safe, pile),
+    end_turn = GameplayLayout.get_end_turn_rect(safe, hand_layout, hand, end_turn),
+    incoming_hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
   }
 end
 


### PR DESCRIPTION
## Summary
- extract gameplay-screen geometry helpers from `app/legacy_runtime.lua` into `ui/layout/gameplay_layout.lua`
- keep runtime behavior unchanged by delegating existing helper calls to the gameplay layout module
- add explicit layout contract tests for gameplay geometry and hazard-card clamping

## What moved
`ui/layout/gameplay_layout.lua` now owns:
- planet position/radius (`get_planet`)
- hand start/base layout (`get_hand_layout`)
- deck/discard rectangles (`get_deck_rect`, `get_discard_rect`)
- end-turn button rectangle + clamp (`get_end_turn_rect`)
- incoming hazard card rectangle + clamp (`get_hazard_card_rect`)
- composed gameplay layout output (`compute`)

`app/legacy_runtime.lua` now:
- requires `ui.layout.gameplay_layout`
- delegates gameplay geometry helpers (`update_target_layout`, draw/discard/end-turn rects, hazard rect, hand layout) to the layout module
- keeps all rendering, interaction, and turn logic unchanged

## Tests
- added `tests/gameplay_layout_spec.lua` (Given/When/Then geometry and clamp checks)
- registered in `tests/run_math_spec.lua`

Commands run:
- `luac -p app/legacy_runtime.lua ui/layout/gameplay_layout.lua tests/gameplay_layout_spec.lua tests/run_math_spec.lua`
- `lua tests/run_math_spec.lua`
- `lua tests/run_math_suite.lua`
- `lua tests/run_characterization.lua`
