### PR TITLE
Extract card-library layout geometry from legacy runtime

### DIFF
--- a/app/legacy_runtime.lua
+++ b/app/legacy_runtime.lua
@@ -15,6 +15,7 @@ local ActionApplier = require("systems.action_applier")
 local InfluenceUIState = require("app.influence_ui_state")
 local InfluenceLayout = require("ui.layout.influence_layout")
 local GameplayLayout = require("ui.layout.gameplay_layout")
+local CardLibraryLayout = require("ui.layout.card_library_layout")
 
 local VIEWPORT_REF_W = 1728
 local VIEWPORT_REF_H = 798
@@ -1641,95 +1642,14 @@ end
 
 local function get_card_library_layout()
   local sw, sh = love.graphics.getDimensions()
-  local margin = 20
-  local filter_y = 88
-  local filter_h = 28
-  local filter_gap = 8
-  local x = margin
-  local y = filter_y
   local font = love.graphics.getFont()
-  local filter_rects = {}
-
-  for _, topic in ipairs(card_library_state.topics) do
-    local w = math.max(84, font:getWidth(topic) + 22)
-    if x + w > sw - margin then
-      x = margin
-      y = y + filter_h + filter_gap
-    end
-    table.insert(filter_rects, {
-      topic = topic,
-      x = x,
-      y = y,
-      w = w,
-      h = filter_h
-    })
-    x = x + w + filter_gap
-  end
-
-  local filters_bottom = y + filter_h
-  local content_top = filters_bottom + 12
-  local detail_w = math.max(300, math.floor(sw * 0.29))
-  local content_h = math.max(220, sh - content_top - 20)
-  local grid_w = sw - (margin * 2) - detail_w - 12
-  if grid_w < 380 then
-    detail_w = math.max(260, math.floor(sw * 0.34))
-    grid_w = sw - (margin * 2) - detail_w - 12
-  end
-  local grid_rect = {
-    x = margin,
-    y = content_top,
-    w = grid_w,
-    h = content_h
-  }
-  local detail_rect = {
-    x = grid_rect.x + grid_rect.w + 12,
-    y = content_top,
-    w = detail_w,
-    h = content_h
-  }
-
-  return {
-    filter_rects = filter_rects,
-    grid_rect = grid_rect,
-    detail_rect = detail_rect
-  }
+  return CardLibraryLayout.compute_for_window(sw, sh, card_library_state.topics, function(text)
+    return font:getWidth(text)
+  end)
 end
 
 local function get_card_library_card_rects(layout, filtered_entries)
-  local grid_rect = layout.grid_rect
-  local inner_pad = 10
-  local card_w = 150
-  local card_h = 225
-  local gap_x = 14
-  local gap_y = 16
-  local usable_w = math.max(1, grid_rect.w - (inner_pad * 2))
-  local cols = math.max(1, math.floor((usable_w + gap_x) / (card_w + gap_x)))
-  local used_w = cols * card_w + (cols - 1) * gap_x
-  local start_x = grid_rect.x + inner_pad + math.max(0, math.floor((usable_w - used_w) / 2))
-  local start_y = grid_rect.y + inner_pad - card_library_state.scroll_offset
-
-  local rects = {}
-  for i, entry in ipairs(filtered_entries) do
-    local row = math.floor((i - 1) / cols)
-    local col = (i - 1) % cols
-    local x = start_x + col * (card_w + gap_x)
-    local y = start_y + row * (card_h + gap_y)
-    table.insert(rects, {
-      x = x,
-      y = y,
-      w = card_w,
-      h = card_h,
-      entry = entry
-    })
-  end
-
-  local rows = math.ceil(#filtered_entries / cols)
-  local total_h = 0
-  if rows > 0 then
-    total_h = rows * card_h + (rows - 1) * gap_y
-  end
-  local max_scroll = math.max(0, total_h - (grid_rect.h - inner_pad * 2))
-  return rects, max_scroll
+  return CardLibraryLayout.get_card_rects(layout.grid_rect, filtered_entries, card_library_state.scroll_offset)
 end
 
 local function get_card_library_selected_entry(filtered_entries)

--- a/tests/card_library_layout_spec.lua
+++ b/tests/card_library_layout_spec.lua
@@ -1,0 +1,125 @@
+local CardLibraryLayout = require("ui.layout.card_library_layout")
+
+local CardLibraryLayoutSpec = {}
+
+local function make_result()
+  return {
+    logs = {},
+    failed = 0
+  }
+end
+
+local function add_log(result, line)
+  result.logs[#result.logs + 1] = line
+end
+
+local function expect_equal(result, label, actual, expected)
+  local ok = actual == expected
+  local status = ok and "PASS" or "FAIL"
+  add_log(result, string.format("THEN %s: %s (expected %s, got %s)", status, label, tostring(expected), tostring(actual)))
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function run_compute_window_contract()
+  local result = make_result()
+  local topics = { "All", "Terraform", "Industry" }
+  local measure = function(text)
+    return #text * 8
+  end
+
+  add_log(result, "GIVEN a compact card-library window and deterministic text widths")
+  local layout = CardLibraryLayout.compute_for_window(400, 300, topics, measure)
+  add_log(result, "WHEN computing filter row + content panes")
+
+  expect_equal(result, "three filter chips are produced", #layout.filter_rects, 3)
+  expect_equal(result, "first filter x", layout.filter_rects[1].x, 20)
+  expect_equal(result, "second filter x", layout.filter_rects[2].x, 112)
+  expect_equal(result, "third filter x", layout.filter_rects[3].x, 214)
+  expect_equal(result, "grid x", layout.grid_rect.x, 20)
+  expect_equal(result, "grid y", layout.grid_rect.y, 128)
+  expect_equal(result, "grid width after narrow fallback", layout.grid_rect.w, 88)
+  expect_equal(result, "detail panel width after fallback", layout.detail_rect.w, 260)
+  expect_equal(result, "detail panel x", layout.detail_rect.x, 120)
+  return result
+end
+
+local function run_filter_wrap_contract()
+  local result = make_result()
+  local topics = { "TopicA", "TopicB", "TopicC" }
+  local measure = function(_)
+    return 88
+  end
+
+  add_log(result, "GIVEN chip widths that force filter wrapping")
+  local layout = CardLibraryLayout.compute_for_window(260, 380, topics, measure)
+  add_log(result, "WHEN computing filter chip positions")
+
+  expect_equal(result, "first chip first row", layout.filter_rects[1].y, 88)
+  expect_equal(result, "second chip wraps to second row", layout.filter_rects[2].y, 124)
+  expect_equal(result, "third chip wraps to third row", layout.filter_rects[3].y, 160)
+  return result
+end
+
+local function run_card_rects_contract()
+  local result = make_result()
+  local grid_rect = { x = 20, y = 120, w = 500, h = 320 }
+  local entries = {}
+  for i = 1, 7 do
+    entries[i] = { id = i }
+  end
+
+  add_log(result, "GIVEN a grid rect and seven card entries")
+  local rects, max_scroll = CardLibraryLayout.get_card_rects(grid_rect, entries, 44)
+  add_log(result, "WHEN generating scrolled card rects")
+
+  expect_equal(result, "all entries produce rects", #rects, 7)
+  expect_equal(result, "first rect x", rects[1].x, 31)
+  expect_equal(result, "first rect y applies scroll offset", rects[1].y, 86)
+  expect_equal(result, "fourth rect starts second row", rects[4].y, 327)
+  expect_equal(result, "computed max scroll", max_scroll, 407)
+  return result
+end
+
+local function run_named_scenario(name, fn)
+  print("")
+  print("Scenario: " .. name)
+  local ok, result_or_err = pcall(fn)
+  if not ok then
+    print("  THEN FAIL: " .. tostring(result_or_err))
+    return 0, 1
+  end
+
+  for _, line in ipairs(result_or_err.logs or {}) do
+    print("  " .. line)
+  end
+
+  if (result_or_err.failed or 0) == 0 then
+    print("  RESULT: PASS")
+    return 1, 0
+  end
+
+  print("  RESULT: FAIL (" .. tostring(result_or_err.failed) .. " check(s) failed)")
+  return 0, 1
+end
+
+function CardLibraryLayoutSpec.run()
+  local scenarios = {
+    { name = "Card Library Window Layout Contract", fn = run_compute_window_contract },
+    { name = "Card Library Filter Wrap Contract", fn = run_filter_wrap_contract },
+    { name = "Card Library Card Rects Contract", fn = run_card_rects_contract }
+  }
+
+  local passed = 0
+  local failed = 0
+  for _, scenario in ipairs(scenarios) do
+    local scenario_passed, scenario_failed = run_named_scenario(scenario.name, scenario.fn)
+    passed = passed + scenario_passed
+    failed = failed + scenario_failed
+  end
+
+  return passed, failed
+end
+
+return CardLibraryLayoutSpec

--- a/tests/run_math_spec.lua
+++ b/tests/run_math_spec.lua
@@ -13,6 +13,7 @@ local ActionApplierSpec = require("tests.action_applier_spec")
 local InfluenceUIStateSpec = require("tests.influence_ui_state_spec")
 local InfluenceLayoutSpec = require("tests.influence_layout_spec")
 local GameplayLayoutSpec = require("tests.gameplay_layout_spec")
+local CardLibraryLayoutSpec = require("tests.card_library_layout_spec")
 
 local function run_section(name, fn)
   print("")
@@ -48,6 +49,10 @@ failed_total = failed_total + f5
 local p6, f6 = run_section("Gameplay Layout Spec", GameplayLayoutSpec.run)
 passed_total = passed_total + p6
 failed_total = failed_total + f6
+
+local p7, f7 = run_section("Card Library Layout Spec", CardLibraryLayoutSpec.run)
+passed_total = passed_total + p7
+failed_total = failed_total + f7
 
 print("")
 print(string.format("math spec suite: %d scenario(s) passed, %d failed", passed_total, failed_total))

--- a/ui/layout/card_library_layout.lua
+++ b/ui/layout/card_library_layout.lua
@@ -21,4 +21,100 @@ function CardLibraryLayout.compute(safe_rect)
   }
 end
 
+function CardLibraryLayout.compute_for_window(window_w, window_h, topics, measure_text)
+  local sw = window_w or 0
+  local sh = window_h or 0
+  local margin = 20
+  local filter_y = 88
+  local filter_h = 28
+  local filter_gap = 8
+  local x = margin
+  local y = filter_y
+  local measure = measure_text or function(text)
+    return #(text or "")
+  end
+  local filter_rects = {}
+
+  for _, topic in ipairs(topics or {}) do
+    local w = math.max(84, measure(topic) + 22)
+    if x + w > sw - margin then
+      x = margin
+      y = y + filter_h + filter_gap
+    end
+    table.insert(filter_rects, {
+      topic = topic,
+      x = x,
+      y = y,
+      w = w,
+      h = filter_h
+    })
+    x = x + w + filter_gap
+  end
+
+  local filters_bottom = y + filter_h
+  local content_top = filters_bottom + 12
+  local detail_w = math.max(300, math.floor(sw * 0.29))
+  local content_h = math.max(220, sh - content_top - 20)
+  local grid_w = sw - (margin * 2) - detail_w - 12
+  if grid_w < 380 then
+    detail_w = math.max(260, math.floor(sw * 0.34))
+    grid_w = sw - (margin * 2) - detail_w - 12
+  end
+
+  local grid_rect = {
+    x = margin,
+    y = content_top,
+    w = grid_w,
+    h = content_h
+  }
+  local detail_rect = {
+    x = grid_rect.x + grid_rect.w + 12,
+    y = content_top,
+    w = detail_w,
+    h = content_h
+  }
+
+  return {
+    filter_rects = filter_rects,
+    grid_rect = grid_rect,
+    detail_rect = detail_rect
+  }
+end
+
+function CardLibraryLayout.get_card_rects(grid_rect, filtered_entries, scroll_offset)
+  local inner_pad = 10
+  local card_w = 150
+  local card_h = 225
+  local gap_x = 14
+  local gap_y = 16
+  local usable_w = math.max(1, grid_rect.w - (inner_pad * 2))
+  local cols = math.max(1, math.floor((usable_w + gap_x) / (card_w + gap_x)))
+  local used_w = cols * card_w + (cols - 1) * gap_x
+  local start_x = grid_rect.x + inner_pad + math.max(0, math.floor((usable_w - used_w) / 2))
+  local start_y = grid_rect.y + inner_pad - (scroll_offset or 0)
+
+  local rects = {}
+  for i, entry in ipairs(filtered_entries or {}) do
+    local row = math.floor((i - 1) / cols)
+    local col = (i - 1) % cols
+    local x = start_x + col * (card_w + gap_x)
+    local y = start_y + row * (card_h + gap_y)
+    table.insert(rects, {
+      x = x,
+      y = y,
+      w = card_w,
+      h = card_h,
+      entry = entry
+    })
+  end
+
+  local rows = math.ceil(#(filtered_entries or {}) / cols)
+  local total_h = 0
+  if rows > 0 then
+    total_h = rows * card_h + (rows - 1) * gap_y
+  end
+  local max_scroll = math.max(0, total_h - (grid_rect.h - inner_pad * 2))
+  return rects, max_scroll
+end
+
 return CardLibraryLayout


### PR DESCRIPTION
## Summary
- extract card-library layout calculations from `app/legacy_runtime.lua` into `ui/layout/card_library_layout.lua`
- keep card-library behavior unchanged by routing existing runtime helpers through the new layout module
- add pure layout specs for filter-row wrapping and card grid/scroll geometry

## What moved
`ui/layout/card_library_layout.lua` now owns:
- `compute_for_window(window_w, window_h, topics, measure_text)`
- `get_card_rects(grid_rect, filtered_entries, scroll_offset)`

`app/legacy_runtime.lua` now:
- requires `ui.layout.card_library_layout`
- delegates `get_card_library_layout` to `CardLibraryLayout.compute_for_window(...)`
- delegates `get_card_library_card_rects` to `CardLibraryLayout.get_card_rects(...)`

## Tests
- added `tests/card_library_layout_spec.lua` with Given/When/Then checks for:
  - window-level pane/filter layout
  - filter wrapping behavior
  - card rect placement and max scroll math
- wired spec into `tests/run_math_spec.lua`

Commands run:
- `luac -p app/legacy_runtime.lua ui/layout/card_library_layout.lua tests/card_library_layout_spec.lua tests/run_math_spec.lua`
- `lua tests/run_math_spec.lua`
- `lua tests/run_math_suite.lua`
- `lua tests/run_characterization.lua`
