### PR TITLE
Refactor: extract card library state model and specs

### DIFF
--- a/app/card_library_state.lua
+++ b/app/card_library_state.lua
@@ -1,0 +1,227 @@
+local CardLibraryState = {}
+
+local CARD_LIBRARY_TOPIC_ORDER = {
+  "Terraform",
+  "Industry",
+  "Chance",
+  "Power",
+  "Heat",
+  "Air",
+  "Water",
+  "Soil",
+  "Economy",
+  "Draw",
+  "Stabilize",
+  "Stat Change"
+}
+
+local CATEGORY_SORT_ORDER = {
+  Terraform = 1,
+  Industry = 2,
+  Chance = 3,
+  Power = 4
+}
+
+local function clamp_value(value, min_value, max_value)
+  if value < min_value then
+    return min_value
+  end
+  if value > max_value then
+    return max_value
+  end
+  return value
+end
+
+local function get_topics_for_card(card_data, stat_labels)
+  local labels = stat_labels or {}
+  local topics = {}
+  local function add(topic)
+    if topic and topic ~= "" then
+      topics[topic] = true
+    end
+  end
+
+  add(card_data.category)
+  local properties = card_data.properties or {}
+  local changes = properties.stat_changes
+  if changes then
+    add("Stat Change")
+    for stat_key, _ in pairs(changes) do
+      add(labels[stat_key] or stat_key)
+    end
+  end
+
+  if card_data.effect_fn_name == "install_industry" then
+    add("Economy")
+    add("Industry")
+  elseif card_data.effect_fn_name == "draw_cards" then
+    add("Draw")
+  elseif card_data.effect_fn_name == "stabilize_system" then
+    add("Stabilize")
+  end
+
+  return topics
+end
+
+function CardLibraryState.new()
+  return {
+    cards = {},
+    topics = { "All" },
+    selected_topic = "All",
+    selected_card_id = nil,
+    hovered_topic = nil,
+    hovered_card_id = nil,
+    scroll_offset = 0,
+    max_scroll = 0
+  }
+end
+
+function CardLibraryState.reset_hover(state)
+  state.hovered_topic = nil
+  state.hovered_card_id = nil
+end
+
+function CardLibraryState.initialize(state, opts)
+  local options = opts or {}
+  local card_types = options.card_types or require("card_types")
+  local card_class = options.card_class or require("card")
+  local stat_labels = options.stat_labels or {}
+
+  local card_ids = card_types.getAllCardIds()
+  table.sort(card_ids)
+
+  local entries = {}
+  local topic_presence = {}
+  for _, card_id in ipairs(card_ids) do
+    local card_data = card_types.createCardData(card_id)
+    local topics = get_topics_for_card(card_data, stat_labels)
+    for topic, _ in pairs(topics) do
+      topic_presence[topic] = true
+    end
+    table.insert(entries, {
+      id = card_id,
+      data = card_data,
+      card = card_class:new(card_data),
+      topics = topics
+    })
+  end
+
+  table.sort(entries, function(a, b)
+    local ca = CATEGORY_SORT_ORDER[a.data.category] or 99
+    local cb = CATEGORY_SORT_ORDER[b.data.category] or 99
+    if ca == cb then
+      return string.lower(a.data.name) < string.lower(b.data.name)
+    end
+    return ca < cb
+  end)
+
+  local topics = { "All" }
+  for _, topic in ipairs(CARD_LIBRARY_TOPIC_ORDER) do
+    if topic_presence[topic] then
+      table.insert(topics, topic)
+      topic_presence[topic] = nil
+    end
+  end
+
+  local extra_topics = {}
+  for topic, _ in pairs(topic_presence) do
+    table.insert(extra_topics, topic)
+  end
+  table.sort(extra_topics)
+  for _, topic in ipairs(extra_topics) do
+    table.insert(topics, topic)
+  end
+
+  state.cards = entries
+  state.topics = topics
+  state.selected_topic = "All"
+  state.selected_card_id = entries[1] and entries[1].id or nil
+  state.scroll_offset = 0
+  state.max_scroll = 0
+  CardLibraryState.reset_hover(state)
+end
+
+function CardLibraryState.get_filtered_entries(state)
+  local filtered = {}
+  local selected_topic = state.selected_topic
+  for _, entry in ipairs(state.cards or {}) do
+    if selected_topic == "All" or entry.topics[selected_topic] then
+      table.insert(filtered, entry)
+    end
+  end
+  return filtered
+end
+
+function CardLibraryState.ensure_selection(state, filtered)
+  if #filtered == 0 then
+    state.selected_card_id = nil
+    return
+  end
+
+  local selected_id = state.selected_card_id
+  for _, entry in ipairs(filtered) do
+    if entry.id == selected_id then
+      return
+    end
+  end
+  state.selected_card_id = filtered[1].id
+end
+
+function CardLibraryState.get_selected_entry(state, filtered)
+  for _, entry in ipairs(filtered) do
+    if entry.id == state.selected_card_id then
+      return entry
+    end
+  end
+  return filtered[1]
+end
+
+function CardLibraryState.set_max_scroll(state, max_scroll)
+  state.max_scroll = math.max(0, max_scroll or 0)
+  state.scroll_offset = clamp_value(state.scroll_offset, 0, state.max_scroll)
+end
+
+function CardLibraryState.select_topic(state, topic)
+  if not topic or topic == "" then
+    return
+  end
+  state.selected_topic = topic
+  state.scroll_offset = 0
+end
+
+function CardLibraryState.select_card(state, card_id)
+  state.selected_card_id = card_id
+end
+
+function CardLibraryState.scroll_by(state, wheel_delta, step)
+  local delta = wheel_delta or 0
+  local amount = step or 44
+  state.scroll_offset = clamp_value(state.scroll_offset - delta * amount, 0, state.max_scroll)
+end
+
+function CardLibraryState.cycle_topic(state, direction)
+  local topics = state.topics or {}
+  if #topics == 0 then
+    return nil
+  end
+
+  local current_index = 1
+  for i, topic in ipairs(topics) do
+    if topic == state.selected_topic then
+      current_index = i
+      break
+    end
+  end
+
+  local dir = direction or 1
+  current_index = current_index + dir
+  if current_index < 1 then
+    current_index = #topics
+  elseif current_index > #topics then
+    current_index = 1
+  end
+  CardLibraryState.select_topic(state, topics[current_index])
+  return topics[current_index]
+end
+
+return CardLibraryState

--- a/app/legacy_runtime.lua
+++ b/app/legacy_runtime.lua
@@ -16,6 +16,7 @@ local InfluenceUIState = require("app.influence_ui_state")
 local InfluenceLayout = require("ui.layout.influence_layout")
 local GameplayLayout = require("ui.layout.gameplay_layout")
 local CardLibraryLayout = require("ui.layout.card_library_layout")
+local CardLibraryState = require("app.card_library_state")
 
 local VIEWPORT_REF_W = 1728
 local VIEWPORT_REF_H = 798
@@ -194,17 +195,7 @@ end
 local launch_mode = detect_launch_mode() -- game | cards
 
 local initialize_card_library_state
-
-local card_library_state = {
-  cards = {},
-  topics = { "All" },
-  selected_topic = "All",
-  selected_card_id = nil,
-  hovered_topic = nil,
-  hovered_card_id = nil,
-  scroll_offset = 0,
-  max_scroll = 0
-}
+local card_library_state = CardLibraryState.new()
 
 local function copy_stats(source)
   local out = {}
@@ -1506,138 +1497,20 @@ local function calculate_profit_flow_totals(active_industries, profit_breakdown,
   }
 end
 
-local CARD_LIBRARY_TOPIC_ORDER = {
-  "Terraform",
-  "Industry",
-  "Chance",
-  "Power",
-  "Heat",
-  "Air",
-  "Water",
-  "Soil",
-  "Economy",
-  "Draw",
-  "Stabilize",
-  "Stat Change"
-}
-
-local CATEGORY_SORT_ORDER = {
-  Terraform = 1,
-  Industry = 2,
-  Chance = 3,
-  Power = 4
-}
-
-local function get_card_library_topics_for_card(card_data)
-  local topics = {}
-  local function add(topic)
-    if topic and topic ~= "" then
-      topics[topic] = true
-    end
-  end
-
-  add(card_data.category)
-  local properties = card_data.properties or {}
-  local changes = properties.stat_changes
-  if changes then
-    add("Stat Change")
-    for stat_key, _ in pairs(changes) do
-      add(STAT_LABELS[stat_key] or stat_key)
-    end
-  end
-
-  if card_data.effect_fn_name == "install_industry" then
-    add("Economy")
-    add("Industry")
-  elseif card_data.effect_fn_name == "draw_cards" then
-    add("Draw")
-  elseif card_data.effect_fn_name == "stabilize_system" then
-    add("Stabilize")
-  end
-
-  return topics
-end
-
 initialize_card_library_state = function()
-  local card_ids = CardTypes.getAllCardIds()
-  table.sort(card_ids)
-
-  local entries = {}
-  local topic_presence = {}
-  for _, card_id in ipairs(card_ids) do
-    local card_data = CardTypes.createCardData(card_id)
-    local topics = get_card_library_topics_for_card(card_data)
-    for topic, _ in pairs(topics) do
-      topic_presence[topic] = true
-    end
-    table.insert(entries, {
-      id = card_id,
-      data = card_data,
-      card = Card:new(card_data),
-      topics = topics
-    })
-  end
-
-  table.sort(entries, function(a, b)
-    local ca = CATEGORY_SORT_ORDER[a.data.category] or 99
-    local cb = CATEGORY_SORT_ORDER[b.data.category] or 99
-    if ca == cb then
-      return string.lower(a.data.name) < string.lower(b.data.name)
-    end
-    return ca < cb
-  end)
-
-  local topics = { "All" }
-  for _, topic in ipairs(CARD_LIBRARY_TOPIC_ORDER) do
-    if topic_presence[topic] then
-      table.insert(topics, topic)
-      topic_presence[topic] = nil
-    end
-  end
-
-  local extra_topics = {}
-  for topic, _ in pairs(topic_presence) do
-    table.insert(extra_topics, topic)
-  end
-  table.sort(extra_topics)
-  for _, topic in ipairs(extra_topics) do
-    table.insert(topics, topic)
-  end
-
-  card_library_state.cards = entries
-  card_library_state.topics = topics
-  card_library_state.selected_topic = "All"
-  card_library_state.selected_card_id = entries[1] and entries[1].id or nil
-  card_library_state.hovered_topic = nil
-  card_library_state.hovered_card_id = nil
-  card_library_state.scroll_offset = 0
-  card_library_state.max_scroll = 0
+  CardLibraryState.initialize(card_library_state, {
+    card_types = CardTypes,
+    card_class = Card,
+    stat_labels = STAT_LABELS
+  })
 end
 
 local function get_card_library_filtered_entries()
-  local filtered = {}
-  local selected_topic = card_library_state.selected_topic
-  for _, entry in ipairs(card_library_state.cards) do
-    if selected_topic == "All" or entry.topics[selected_topic] then
-      table.insert(filtered, entry)
-    end
-  end
-  return filtered
+  return CardLibraryState.get_filtered_entries(card_library_state)
 end
 
 local function ensure_card_library_selection(filtered)
-  if #filtered == 0 then
-    card_library_state.selected_card_id = nil
-    return
-  end
-
-  local selected_id = card_library_state.selected_card_id
-  for _, entry in ipairs(filtered) do
-    if entry.id == selected_id then
-      return
-    end
-  end
-  card_library_state.selected_card_id = filtered[1].id
+  CardLibraryState.ensure_selection(card_library_state, filtered)
 end
 
 local function get_card_library_layout()
@@ -1653,12 +1526,7 @@ local function get_card_library_card_rects(layout, filtered_entries)
 end
 
 local function get_card_library_selected_entry(filtered_entries)
-  for _, entry in ipairs(filtered_entries) do
-    if entry.id == card_library_state.selected_card_id then
-      return entry
-    end
-  end
-  return filtered_entries[1]
+  return CardLibraryState.get_selected_entry(card_library_state, filtered_entries)
 end
 
 local function update_card_library_hover_state()
@@ -1667,11 +1535,8 @@ local function update_card_library_hover_state()
   local filtered_entries = get_card_library_filtered_entries()
   ensure_card_library_selection(filtered_entries)
   local card_rects, max_scroll = get_card_library_card_rects(layout, filtered_entries)
-  card_library_state.max_scroll = max_scroll
-  card_library_state.scroll_offset = clamp_value(card_library_state.scroll_offset, 0, max_scroll)
-
-  card_library_state.hovered_topic = nil
-  card_library_state.hovered_card_id = nil
+  CardLibraryState.set_max_scroll(card_library_state, max_scroll)
+  CardLibraryState.reset_hover(card_library_state)
 
   for _, filter_rect in ipairs(layout.filter_rects) do
     if point_in_rect(mx, my, filter_rect.x, filter_rect.y, filter_rect.w, filter_rect.h) then
@@ -1695,8 +1560,7 @@ local function draw_card_library_screen()
   local filtered_entries = get_card_library_filtered_entries()
   ensure_card_library_selection(filtered_entries)
   local card_rects, max_scroll = get_card_library_card_rects(layout, filtered_entries)
-  card_library_state.max_scroll = max_scroll
-  card_library_state.scroll_offset = clamp_value(card_library_state.scroll_offset, 0, max_scroll)
+  CardLibraryState.set_max_scroll(card_library_state, max_scroll)
   local selected_entry = get_card_library_selected_entry(filtered_entries)
 
   Background.draw_fill()
@@ -1864,13 +1728,11 @@ local function handle_card_library_mousepressed(x, y)
   local filtered_entries = get_card_library_filtered_entries()
   ensure_card_library_selection(filtered_entries)
   local card_rects, max_scroll = get_card_library_card_rects(layout, filtered_entries)
-  card_library_state.max_scroll = max_scroll
-  card_library_state.scroll_offset = clamp_value(card_library_state.scroll_offset, 0, max_scroll)
+  CardLibraryState.set_max_scroll(card_library_state, max_scroll)
 
   for _, filter_rect in ipairs(layout.filter_rects) do
     if point_in_rect(x, y, filter_rect.x, filter_rect.y, filter_rect.w, filter_rect.h) then
-      card_library_state.selected_topic = filter_rect.topic
-      card_library_state.scroll_offset = 0
+      CardLibraryState.select_topic(card_library_state, filter_rect.topic)
       local refreshed = get_card_library_filtered_entries()
       ensure_card_library_selection(refreshed)
       return
@@ -1881,19 +1743,14 @@ local function handle_card_library_mousepressed(x, y)
   for _, rect in ipairs(card_rects) do
     local visible = rect.y + rect.h >= grid_rect.y and rect.y <= grid_rect.y + grid_rect.h
     if visible and point_in_rect(x, y, rect.x, rect.y, rect.w, rect.h) then
-      card_library_state.selected_card_id = rect.entry.id
+      CardLibraryState.select_card(card_library_state, rect.entry.id)
       return
     end
   end
 end
 
 local function handle_card_library_wheel(y)
-  local step = 44
-  card_library_state.scroll_offset = clamp_value(
-    card_library_state.scroll_offset - y * step,
-    0,
-    card_library_state.max_scroll
-  )
+  CardLibraryState.scroll_by(card_library_state, y, 44)
 end
 
 local function handle_card_library_keypressed(key)
@@ -1910,32 +1767,13 @@ local function handle_card_library_keypressed(key)
     return
   end
 
-  local topics = card_library_state.topics
-  local current_index = 1
-  for i, topic in ipairs(topics) do
-    if topic == card_library_state.selected_topic then
-      current_index = i
-      break
-    end
-  end
-
   if key == "left" then
-    current_index = current_index - 1
-    if current_index < 1 then
-      current_index = #topics
-    end
-    card_library_state.selected_topic = topics[current_index]
-    card_library_state.scroll_offset = 0
+    CardLibraryState.cycle_topic(card_library_state, -1)
     local filtered = get_card_library_filtered_entries()
     ensure_card_library_selection(filtered)
     return
   elseif key == "right" then
-    current_index = current_index + 1
-    if current_index > #topics then
-      current_index = 1
-    end
-    card_library_state.selected_topic = topics[current_index]
-    card_library_state.scroll_offset = 0
+    CardLibraryState.cycle_topic(card_library_state, 1)
     local filtered = get_card_library_filtered_entries()
     ensure_card_library_selection(filtered)
     return

--- a/tests/card_library_state_spec.lua
+++ b/tests/card_library_state_spec.lua
@@ -1,0 +1,208 @@
+local CardLibraryState = require("app.card_library_state")
+
+local CardLibraryStateSpec = {}
+
+local function make_result()
+  return {
+    logs = {},
+    failed = 0
+  }
+end
+
+local function add_log(result, line)
+  result.logs[#result.logs + 1] = line
+end
+
+local function expect_equal(result, label, actual, expected)
+  local ok = actual == expected
+  local status = ok and "PASS" or "FAIL"
+  add_log(result, string.format("THEN %s: %s (expected %s, got %s)", status, label, tostring(expected), tostring(actual)))
+  if not ok then
+    result.failed = result.failed + 1
+  end
+end
+
+local function make_stub_card_types()
+  local defs = {
+    a = {
+      id = "a",
+      name = "Stabilize Alpha",
+      category = "Terraform",
+      cost = 1,
+      description = "stabilize",
+      effect_fn_name = "stabilize_system",
+      properties = {
+        stat_changes = { heat = 1 }
+      }
+    },
+    b = {
+      id = "b",
+      name = "Mine Beta",
+      category = "Industry",
+      cost = 1,
+      description = "install industry",
+      effect_fn_name = "install_industry",
+      properties = {
+        industry_def = { name = "Mine", base_profit = 2 }
+      }
+    },
+    c = {
+      id = "c",
+      name = "Survey Gamma",
+      category = "Chance",
+      cost = 1,
+      description = "draw",
+      effect_fn_name = "draw_cards",
+      properties = {
+        draw_amount = 2
+      }
+    }
+  }
+
+  return {
+    getAllCardIds = function()
+      return { "c", "a", "b" }
+    end,
+    createCardData = function(id)
+      local card = defs[id]
+      if not card then
+        return nil
+      end
+      local clone = {}
+      for k, v in pairs(card) do
+        clone[k] = v
+      end
+      return clone
+    end
+  }
+end
+
+local function make_stub_card_class()
+  return {
+    new = function(_, data)
+      return {
+        name = data.name,
+        data = data
+      }
+    end
+  }
+end
+
+local function run_initialize_contract()
+  local result = make_result()
+  local state = CardLibraryState.new()
+  local card_types = make_stub_card_types()
+  local card_class = make_stub_card_class()
+
+  add_log(result, "GIVEN unsorted card ids and mixed categories")
+  CardLibraryState.initialize(state, {
+    card_types = card_types,
+    card_class = card_class,
+    stat_labels = {
+      heat = "Heat",
+      air = "Air",
+      water = "Water",
+      soil = "Soil"
+    }
+  })
+  add_log(result, "WHEN card library state initializes")
+
+  expect_equal(result, "cards are category-sorted first", state.cards[1].id, "a")
+  expect_equal(result, "industry card is second", state.cards[2].id, "b")
+  expect_equal(result, "chance card is third", state.cards[3].id, "c")
+  expect_equal(result, "selected topic defaults to All", state.selected_topic, "All")
+  expect_equal(result, "selected card defaults to first entry", state.selected_card_id, "a")
+  expect_equal(result, "topics include Terraform", state.topics[2], "Terraform")
+  expect_equal(result, "topics include Industry", state.topics[3], "Industry")
+  expect_equal(result, "topics include Chance", state.topics[4], "Chance")
+  expect_equal(result, "topics include Heat from stat change", state.topics[5], "Heat")
+  return result
+end
+
+local function run_filter_selection_contract()
+  local result = make_result()
+  local state = CardLibraryState.new()
+  CardLibraryState.initialize(state, {
+    card_types = make_stub_card_types(),
+    card_class = make_stub_card_class(),
+    stat_labels = { heat = "Heat" }
+  })
+
+  add_log(result, "GIVEN topic selection and stale card selection")
+  CardLibraryState.select_topic(state, "Industry")
+  state.selected_card_id = "does-not-exist"
+  local filtered = CardLibraryState.get_filtered_entries(state)
+  CardLibraryState.ensure_selection(state, filtered)
+  add_log(result, "WHEN filtering by Industry and ensuring selection")
+
+  expect_equal(result, "one card remains in Industry filter", #filtered, 1)
+  expect_equal(result, "selected card corrected to available card", state.selected_card_id, "b")
+  expect_equal(result, "selected entry resolves from filtered list", CardLibraryState.get_selected_entry(state, filtered).id, "b")
+  return result
+end
+
+local function run_scroll_and_cycle_contract()
+  local result = make_result()
+  local state = CardLibraryState.new()
+  state.topics = { "All", "Terraform", "Industry" }
+  state.selected_topic = "All"
+
+  add_log(result, "GIVEN topic cycling and scroll clamp behavior")
+  local left_topic = CardLibraryState.cycle_topic(state, -1)
+  expect_equal(result, "left cycle wraps to last topic", left_topic, "Industry")
+  local right_topic = CardLibraryState.cycle_topic(state, 1)
+  expect_equal(result, "right cycle returns to first topic", right_topic, "All")
+
+  CardLibraryState.set_max_scroll(state, 120)
+  CardLibraryState.scroll_by(state, -10, 44)
+  expect_equal(result, "scroll clamps to max", state.scroll_offset, 120)
+  CardLibraryState.scroll_by(state, 10, 44)
+  expect_equal(result, "scroll clamps to min", state.scroll_offset, 0)
+
+  state.scroll_offset = 77
+  CardLibraryState.select_topic(state, "Terraform")
+  expect_equal(result, "topic selection resets scroll", state.scroll_offset, 0)
+  return result
+end
+
+local function run_named_scenario(name, fn)
+  print("")
+  print("Scenario: " .. name)
+  local ok, result_or_err = pcall(fn)
+  if not ok then
+    print("  THEN FAIL: " .. tostring(result_or_err))
+    return 0, 1
+  end
+
+  for _, line in ipairs(result_or_err.logs or {}) do
+    print("  " .. line)
+  end
+
+  if (result_or_err.failed or 0) == 0 then
+    print("  RESULT: PASS")
+    return 1, 0
+  end
+
+  print("  RESULT: FAIL (" .. tostring(result_or_err.failed) .. " check(s) failed)")
+  return 0, 1
+end
+
+function CardLibraryStateSpec.run()
+  local scenarios = {
+    { name = "Card Library State Initialize Contract", fn = run_initialize_contract },
+    { name = "Card Library State Filter + Selection Contract", fn = run_filter_selection_contract },
+    { name = "Card Library State Scroll + Topic Cycle Contract", fn = run_scroll_and_cycle_contract }
+  }
+
+  local passed = 0
+  local failed = 0
+  for _, scenario in ipairs(scenarios) do
+    local scenario_passed, scenario_failed = run_named_scenario(scenario.name, scenario.fn)
+    passed = passed + scenario_passed
+    failed = failed + scenario_failed
+  end
+
+  return passed, failed
+end
+
+return CardLibraryStateSpec

--- a/tests/run_math_spec.lua
+++ b/tests/run_math_spec.lua
@@ -14,6 +14,7 @@ local InfluenceUIStateSpec = require("tests.influence_ui_state_spec")
 local InfluenceLayoutSpec = require("tests.influence_layout_spec")
 local GameplayLayoutSpec = require("tests.gameplay_layout_spec")
 local CardLibraryLayoutSpec = require("tests.card_library_layout_spec")
+local CardLibraryStateSpec = require("tests.card_library_state_spec")
 
 local function run_section(name, fn)
   print("")
@@ -53,6 +54,10 @@ failed_total = failed_total + f6
 local p7, f7 = run_section("Card Library Layout Spec", CardLibraryLayoutSpec.run)
 passed_total = passed_total + p7
 failed_total = failed_total + f7
+
+local p8, f8 = run_section("Card Library State Spec", CardLibraryStateSpec.run)
+passed_total = passed_total + p8
+failed_total = failed_total + f8
 
 print("")
 print(string.format("math spec suite: %d scenario(s) passed, %d failed", passed_total, failed_total))


### PR DESCRIPTION
## Summary
- extract card-library state/topic/filter/scroll logic from legacy runtime into `app/card_library_state.lua`
- replace inline card-library state mutations in `app/legacy_runtime.lua` with calls into the new state module
- add a plain-English spec suite for card-library state behavior and wire it into `tests/run_math_spec.lua`

## Why
- continues the refactor track by separating UI orchestration from view-model state logic
- reduces `legacy_runtime` responsibilities without changing gameplay behavior
- adds deterministic coverage around topic ordering, selection fallback, and scroll/cycle invariants

## Validation
- `luac -p app/card_library_state.lua app/legacy_runtime.lua tests/card_library_state_spec.lua tests/run_math_spec.lua`
- `lua tests/run_math_spec.lua`
- `lua tests/run_math_suite.lua`
- `lua tests/run_characterization.lua`
