### PR TITLE
Polish influence map layout with hazard panel and magnetosphere field

### DIFF
--- a/app/influence_ui_state.lua
+++ b/app/influence_ui_state.lua
@@ -23,6 +23,7 @@ function InfluenceUIState:reset_hover_state()
   self.hovered_graph_explain_button = false
   self.hovered_turn_explain_button = false
   self.hovered_objectives_explain_button = false
+  self.hovered_help_button = false
 end
 
 function InfluenceUIState:reset_for_new_campaign()
@@ -33,6 +34,7 @@ function InfluenceUIState:reset_for_new_campaign()
   self.show_graph_explain = false
   self.show_turn_explain = false
   self.show_objectives_explain = false
+  self.show_help_tooltip = false
   self:reset_hover_state()
 end
 
@@ -119,6 +121,10 @@ end
 
 function InfluenceUIState:toggle_objectives_explain()
   self.show_objectives_explain = not self.show_objectives_explain
+end
+
+function InfluenceUIState:toggle_help_tooltip()
+  self.show_help_tooltip = not self.show_help_tooltip
 end
 
 return InfluenceUIState

--- a/app/runtime_context.lua
+++ b/app/runtime_context.lua
@@ -78,8 +78,8 @@ function RuntimeContext.new()
   }
 
   self.END_TURN_UI = {
-    width = 170,
-    height = 50,
+    width = 142,
+    height = 44,
     x_padding = 30,
     y = 520
   }

--- a/app/runtime_context.lua
+++ b/app/runtime_context.lua
@@ -290,7 +290,9 @@ function RuntimeContext:draw_wrapped_line(text, x, y, width, color, line_height)
   love.graphics.printf(text, x, y, width, "left")
   local font = love.graphics.getFont()
   local _, wrapped = font:getWrap(text, width)
-  return y + (math.max(1, #wrapped) * (line_height or 16))
+  local font_h = font:getHeight()
+  local effective_line_height = math.max(line_height or font_h, font_h + 2)
+  return y + (math.max(1, #wrapped) * effective_line_height)
 end
 
 function RuntimeContext:initialize_card_library_state()

--- a/app/runtime_gameplay.lua
+++ b/app/runtime_gameplay.lua
@@ -7,6 +7,7 @@ local DeckWidget = require("ui.components.deck_widget")
 local EnergyOrb = require("ui.components.energy_orb")
 local HazardCard = require("ui.components.hazard_card")
 local GameplayHUD = require("ui.components.gameplay_hud")
+local PrimitiveSnapshot = require("ui.components.primitive_snapshot")
 
 local RuntimeGameplay = {}
 RuntimeGameplay.__index = RuntimeGameplay
@@ -29,7 +30,7 @@ end
 
 function RuntimeGameplay:get_end_turn_rect()
   local hand_layout = self:get_hand_layout(#self.ctx.player_deck.hand)
-  return GameplayLayout.get_end_turn_rect(self.ctx:get_safe_rect(), hand_layout, self.ctx.HAND_UI, self.ctx.END_TURN_UI)
+  return GameplayLayout.get_end_turn_rect(self.ctx:get_safe_rect(), hand_layout, self.ctx.HAND_UI, self.ctx.END_TURN_UI, self.ctx.PILE_UI)
 end
 
 function RuntimeGameplay:get_hazard_card_rect()
@@ -38,6 +39,27 @@ function RuntimeGameplay:get_hazard_card_rect()
     y = self.ctx.target.y,
     radius = self.ctx.target.radius
   })
+end
+
+function RuntimeGameplay:get_primitive_snapshot_anchor()
+  local safe = self.ctx:get_safe_rect()
+  local planet = self.ctx.target
+  local discard_rect = self:get_discard_pile_rect()
+  local end_turn_rect = self:get_end_turn_rect()
+  local radius = 30
+  local half_w = 86 + radius + 10
+  local half_h = 74 + radius + 24
+  local desired_x = planet.x + planet.radius + 154
+  local max_x = safe.x + safe.w - half_w - 4
+  local min_x = safe.x + half_w + 10
+  local min_x_by_planet = planet.x + planet.radius + half_w + 20
+  local desired_y = planet.y + 6
+  local max_y = math.min(discard_rect.y, end_turn_rect.y) - half_h - 14
+  local min_y = safe.y + half_h + 12
+  return {
+    x = self.ctx:clamp_value(desired_x, math.max(min_x, min_x_by_planet), max_x),
+    y = self.ctx:clamp_value(desired_y, min_y, max_y)
+  }
 end
 
 function RuntimeGameplay:update_target_layout()
@@ -136,7 +158,7 @@ end
 function RuntimeGameplay:draw_energy_orb()
   local draw_rect = self:get_draw_pile_rect()
   local cx = draw_rect.x + math.floor(draw_rect.w * 0.5)
-  local cy = draw_rect.y - 26
+  local cy = draw_rect.y - 34
   EnergyOrb.draw(cx, cy, self.ctx.current_energy, self.ctx.max_energy)
 end
 
@@ -161,8 +183,10 @@ function RuntimeGameplay:draw_end_turn_button()
   love.graphics.setLineWidth(1)
 
   love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.printf("END TURN", rect.x, rect.y + 12, rect.w, "center")
-  love.graphics.printf("(E)", rect.x, rect.y + 28, rect.w, "center")
+  local title_y = rect.y + math.floor(rect.h * 0.16)
+  local key_y = rect.y + math.floor(rect.h * 0.5)
+  love.graphics.printf("END TURN", rect.x, title_y, rect.w, "center")
+  love.graphics.printf("(E)", rect.x, key_y, rect.w, "center")
 end
 
 function RuntimeGameplay:draw_hud()
@@ -205,6 +229,24 @@ function RuntimeGameplay:draw_controls_hint()
     clamp_value = function(value, min_value, max_value)
       return self.ctx:clamp_value(value, min_value, max_value)
     end
+  })
+end
+
+function RuntimeGameplay:draw_primitive_snapshot()
+  local anchor = self:get_primitive_snapshot_anchor()
+  PrimitiveSnapshot.draw({
+    center_x = anchor.x,
+    center_y = anchor.y,
+    stats = self.ctx.terraforming_state.stats,
+    stat_order = self.ctx.STAT_ORDER,
+    stat_labels = self.ctx.STAT_LABELS,
+    get_stat_status = function(stat, value)
+      return self.ctx:get_stat_status(stat, value)
+    end,
+    format_signed = function(value)
+      return self.ctx:format_signed(value)
+    end,
+    node_radius = 30
   })
 end
 
@@ -281,6 +323,7 @@ function RuntimeGameplay:draw()
   Background.draw_stars()
   self.ctx.target:draw()
   self:draw_next_hazard_card()
+  self:draw_primitive_snapshot()
   self:draw_hud()
   self:draw_pile_widgets()
   self:draw_end_turn_button()

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -43,6 +43,10 @@ function RuntimeInfluence:get_preview_explain_button(layout)
   return InfluenceLayout.get_preview_explain_button(layout)
 end
 
+function RuntimeInfluence:get_help_button(layout)
+  return InfluenceLayout.get_help_button(layout)
+end
+
 function RuntimeInfluence:get_objectives_explain_button(layout)
   return InfluenceLayout.get_objectives_explain_button(layout)
 end
@@ -227,57 +231,30 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
   local cy = magnetosphere.y
   local left_bound = layout.nodes.air.x - layout.nodes.air.r
   local right_bound = layout.nodes.water.x + layout.nodes.water.r
-  local top_bound = layout.nodes.heat.y - layout.nodes.heat.r
-  local bottom_bound = layout.nodes.soil.y + layout.nodes.soil.r
-  local cluster_h = math.max(120, bottom_bound - top_bound)
-  local graph_right = graph_rect.x + graph_rect.w - 12
+  local vertical_span = math.max(120, (layout.nodes.soil.y - layout.nodes.heat.y) + (layout.nodes.heat.r * 2))
+  local graph_right = graph_rect.x + graph_rect.w - 10
 
   local line_width = love.graphics.getLineWidth()
 
   love.graphics.setScissor(graph_rect.x + 2, graph_rect.y + 2, graph_rect.w - 4, graph_rect.h - 4)
 
-  -- Dayside (left): compressed bow lines kept outside the air node.
-  for i = 1, 5 do
-    local t = (i - 1) / 4
-    local alpha = (0.022 + strength * 0.04) * (1.0 - t * 0.18)
-    local rx = 22 + i * 9
-    local ry = cluster_h * 0.52 + i * 10
-    local cx = left_bound - (44 + i * 7)
-    if cx + rx > left_bound - 8 then
-      cx = (left_bound - 8) - rx
-    end
+  -- 4-shell simplified magnetosphere: compressed left side, pitched right tail.
+  for i = 1, 4 do
+    local t = (i - 1) / 3
+    local alpha = (0.03 + strength * 0.05) * (1.0 - t * 0.2)
+    local left_rx = 24 + i * 8
+    local left_ry = vertical_span * 0.44 + i * 8
+    local left_cx = (left_bound - 12) - left_rx
+
+    local right_cx = right_bound + 6 + i * 3
+    local right_target_rx = 72 + i * 14 + strength * 10
+    local right_rx = math.max(22, math.min(right_target_rx, graph_right - right_cx))
+    local right_ry = vertical_span * 0.34 + i * 7
+
     love.graphics.setColor(0.36, 0.67, 1.0, alpha)
-    love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
-    draw_arc_polyline(cx, cy, rx, ry, math.rad(112), math.rad(248), 26)
-  end
-
-  -- Nightside (right): stretched tail lines, capped to graph bounds.
-  for i = 1, 5 do
-    local t = (i - 1) / 4
-    local alpha = (0.03 + strength * 0.045) * (1.0 - t * 0.16)
-    local tail_cx = right_bound + 8 + i * 2
-    local target_rx = 64 + i * 14 + strength * 14
-    local max_rx = math.max(20, graph_right - tail_cx)
-    local rx = math.min(target_rx, max_rx)
-    local ry = cluster_h * 0.44 + i * 8
-    love.graphics.setColor(0.35, 0.62, 0.98, alpha)
-    love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
-    draw_arc_polyline(tail_cx, cy, rx, ry, math.rad(-58), math.rad(58), 30)
-  end
-
-  -- Bow shock accent in front of the compressed side.
-  local warm_alpha = 0.02 + (1.0 - strength) * 0.055
-  for i = 1, 2 do
-    local fade = 1 - (i - 1) * 0.22
-    local rx = 44 + i * 14
-    local ry = cluster_h * 0.66 + i * 16
-    local shock_cx = left_bound - (78 + i * 14)
-    if shock_cx + rx > left_bound - 20 then
-      shock_cx = (left_bound - 20) - rx
-    end
-    love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha * fade)
-    love.graphics.setLineWidth(1.2)
-    draw_arc_polyline(shock_cx, cy, rx, ry, math.rad(106), math.rad(254), 24)
+    love.graphics.setLineWidth(math.max(1, 1.7 - t * 0.45))
+    draw_arc_polyline(left_cx, cy, left_rx, left_ry, math.rad(112), math.rad(248), 24)
+    draw_arc_polyline(right_cx, cy, right_rx, right_ry, math.rad(-54), math.rad(54), 28)
   end
 
   love.graphics.setScissor()
@@ -528,6 +505,7 @@ end
 function RuntimeInfluence:draw_influence_cards(layout)
   local rect = layout.cards_rect
   local card_rects = self:get_influence_card_rects(layout)
+  local help_button = self:get_help_button(layout)
   local explain_button = self:get_preview_explain_button(layout)
 
   love.graphics.setColor(0.06, 0.08, 0.12, 0.92)
@@ -537,6 +515,18 @@ function RuntimeInfluence:draw_influence_cards(layout)
 
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.printf("Preview Selector (Do Nothing or card). Use Current above to clear preview.", rect.x + 10, rect.y + 10, rect.w - 20, "left")
+
+  local help_fill = self.ctx.influence_ui.show_help_tooltip and { 0.24, 0.42, 0.26, 1 } or { 0.13, 0.18, 0.25, 1 }
+  if self.ctx.influence_ui.hovered_help_button and not self.ctx.influence_ui.show_help_tooltip then
+    help_fill = { 0.18, 0.24, 0.33, 1 }
+  end
+  local help_border = self.ctx.influence_ui.show_help_tooltip and { 0.65, 0.95, 0.64, 1 } or { 0.62, 0.78, 0.95, 1 }
+  love.graphics.setColor(unpack(help_fill))
+  love.graphics.rectangle("fill", help_button.x, help_button.y, help_button.w, help_button.h, 7, 7)
+  love.graphics.setColor(unpack(help_border))
+  love.graphics.rectangle("line", help_button.x, help_button.y, help_button.w, help_button.h, 7, 7)
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf("?", help_button.x, help_button.y + 4, help_button.w, "center")
 
   local turn_fill = self.ctx.influence_ui.show_turn_explain and { 0.24, 0.42, 0.26, 1 } or { 0.13, 0.18, 0.25, 1 }
   if self.ctx.influence_ui.hovered_turn_explain_button and not self.ctx.influence_ui.show_turn_explain then
@@ -597,21 +587,69 @@ function RuntimeInfluence:draw_influence_cards(layout)
   end
 end
 
+function RuntimeInfluence:draw_screen_header(safe)
+  local title = "Core Influence Map (V)"
+  local font = love.graphics.getFont()
+  local box_w = font:getWidth(title) + 26
+  local box_h = font:getHeight() + 10
+  local box_x = safe.x + math.floor((safe.w - box_w) * 0.5)
+  local box_y = safe.y - 2
+
+  love.graphics.setColor(0.07, 0.1, 0.16, 0.95)
+  love.graphics.rectangle("fill", box_x, box_y, box_w, box_h, 8, 8)
+  love.graphics.setColor(0.72, 0.82, 0.96, 1)
+  love.graphics.rectangle("line", box_x, box_y, box_w, box_h, 8, 8)
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf(title, box_x, box_y + 5, box_w, "center")
+end
+
+function RuntimeInfluence:draw_help_tooltip(layout)
+  if not self.ctx.influence_ui.show_help_tooltip then
+    return
+  end
+
+  local safe = self.ctx:get_safe_rect()
+  local help_button = self:get_help_button(layout)
+  local panel_w = math.min(660, math.floor(safe.w * 0.56))
+  local panel_h = 112
+  local panel_x = layout.cards_rect.x + 12
+  local panel_y = help_button.y - panel_h - 8
+  if panel_y < safe.y + 34 then
+    panel_y = safe.y + 34
+  end
+
+  love.graphics.setColor(0.04, 0.06, 0.1, 0.98)
+  love.graphics.rectangle("fill", panel_x, panel_y, panel_w, panel_h, 10, 10)
+  love.graphics.setColor(0.72, 0.82, 0.96, 1)
+  love.graphics.rectangle("line", panel_x, panel_y, panel_w, panel_h, 10, 10)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf("Influence Map Help", panel_x + 12, panel_y + 10, panel_w - 24, "left")
+  love.graphics.setColor(0.86, 0.92, 0.98, 1)
+  love.graphics.printf(
+    "Click primitive to focus. Arrows show coupling for the selected reference mode; blue marker shows card push.",
+    panel_x + 12,
+    panel_y + 30,
+    panel_w - 24,
+    "left"
+  )
+  love.graphics.printf(
+    "M mapping | C clear card | I flow | Z current | X do nothing | P selected card | V gameplay",
+    panel_x + 12,
+    panel_y + 66,
+    panel_w - 24,
+    "left"
+  )
+end
+
 function RuntimeInfluence:draw_influence_screen()
   local safe = self.ctx:get_safe_rect()
-  local heading_x = safe.x
-  local heading_y = safe.y - 8
   local layout = self:get_influence_layout()
   local forecast_ctx = self.ctx:get_forecast_context()
 
   Background.draw_fill()
   Background.draw_stars()
-
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("Core Influence Map (V)", heading_x, heading_y)
-  love.graphics.print("Click primitive to focus. Arrows show coupling for the selected reference mode; blue marker shows card push.", heading_x, heading_y + 20)
-  love.graphics.print("Use Explain Graph, Explain Next Turn, and Explain Objectives for detailed breakdowns.", heading_x, heading_y + 40)
-  love.graphics.print("M mapping, C clear card, I flow, Z current, X do nothing, P selected card, V gameplay.", heading_x, heading_y + 60)
+  self:draw_screen_header(safe)
 
   self:draw_incoming_hazard_panel(layout)
   self:draw_influence_nodes(layout, forecast_ctx)
@@ -623,6 +661,7 @@ function RuntimeInfluence:draw_influence_screen()
     self:draw_forecast_panel(layout.turn_explain_rect, forecast_ctx)
   end
   self:draw_influence_cards(layout)
+  self:draw_help_tooltip(layout)
 
   if self.ctx.campaign_state ~= "playing" then
     self:draw_status_overlay()
@@ -685,6 +724,8 @@ function RuntimeInfluence:update(_dt)
 
   local explain_button = self:get_preview_explain_button(layout)
   self.ctx.influence_ui.hovered_turn_explain_button = self.ctx:point_in_rect(mx, my, explain_button.x, explain_button.y, explain_button.w, explain_button.h)
+  local help_button = self:get_help_button(layout)
+  self.ctx.influence_ui.hovered_help_button = self.ctx:point_in_rect(mx, my, help_button.x, help_button.y, help_button.w, help_button.h)
 
   local objectives_explain_button = self:get_objectives_explain_button(layout)
   self.ctx.influence_ui.hovered_objectives_explain_button = self.ctx:point_in_rect(
@@ -827,6 +868,12 @@ function RuntimeInfluence:mousepressed(x, y, button)
   end
 
   local explain_button = self:get_preview_explain_button(layout)
+  local help_button = self:get_help_button(layout)
+  if self.ctx:point_in_rect(mapped_x, mapped_y, help_button.x, help_button.y, help_button.w, help_button.h) then
+    self.ctx.influence_ui:toggle_help_tooltip()
+    return
+  end
+
   if self.ctx:point_in_rect(mapped_x, mapped_y, explain_button.x, explain_button.y, explain_button.w, explain_button.h) then
     self.ctx.influence_ui:toggle_turn_explain()
     return

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -346,15 +346,15 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   local legend_row2_y = legend_row1_y + font_h + 4
 
   love.graphics.setColor(0.45, 0.95, 0.45, 1)
-  love.graphics.circle("fill", map_rect.x + 18, legend_row1_y + 7)
+  love.graphics.circle("fill", map_rect.x + 18, legend_row1_y + 7, 7)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.print("+ target impact", map_rect.x + 30, legend_row1_y)
   love.graphics.setColor(0.98, 0.45, 0.45, 1)
-  love.graphics.circle("fill", map_rect.x + 166, legend_row1_y + 7)
+  love.graphics.circle("fill", map_rect.x + 166, legend_row1_y + 7, 7)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.print("- target impact", map_rect.x + 178, legend_row1_y)
   love.graphics.setColor(0.62, 0.66, 0.74, 1)
-  love.graphics.circle("fill", map_rect.x + 314, legend_row1_y + 7)
+  love.graphics.circle("fill", map_rect.x + 314, legend_row1_y + 7, 7)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.print("0 neutral", map_rect.x + 326, legend_row1_y)
 

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -232,7 +232,7 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
   local left_bound = layout.nodes.air.x - layout.nodes.air.r
   local right_bound = layout.nodes.water.x + layout.nodes.water.r
   local vertical_span = math.max(120, (layout.nodes.soil.y - layout.nodes.heat.y) + (layout.nodes.heat.r * 2))
-  local graph_right = graph_rect.x + graph_rect.w - 10
+  local graph_right = graph_rect.x + graph_rect.w - 14
 
   local line_width = love.graphics.getLineWidth()
 
@@ -241,20 +241,20 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
   -- 4-shell simplified magnetosphere: compressed left side, pitched right tail.
   for i = 1, 4 do
     local t = (i - 1) / 3
-    local alpha = (0.03 + strength * 0.05) * (1.0 - t * 0.2)
-    local left_rx = 24 + i * 8
-    local left_ry = vertical_span * 0.44 + i * 8
-    local left_cx = (left_bound - 12) - left_rx
+    local alpha = (0.028 + strength * 0.045) * (1.0 - t * 0.2)
+    local left_rx = 20 + i * 6
+    local left_ry = vertical_span * 0.40 + i * 6
+    local left_cx = (left_bound - 10) - left_rx
 
-    local right_cx = right_bound + 6 + i * 3
-    local right_target_rx = 72 + i * 14 + strength * 10
+    local right_cx = right_bound + 3 + i * 2
+    local right_target_rx = 52 + i * 11 + strength * 8
     local right_rx = math.max(22, math.min(right_target_rx, graph_right - right_cx))
-    local right_ry = vertical_span * 0.34 + i * 7
+    local right_ry = vertical_span * 0.30 + i * 6
 
     love.graphics.setColor(0.36, 0.67, 1.0, alpha)
     love.graphics.setLineWidth(math.max(1, 1.7 - t * 0.45))
     draw_arc_polyline(left_cx, cy, left_rx, left_ry, math.rad(112), math.rad(248), 24)
-    draw_arc_polyline(right_cx, cy, right_rx, right_ry, math.rad(-54), math.rad(54), 28)
+    draw_arc_polyline(right_cx, cy, right_rx, right_ry, math.rad(-48), math.rad(48), 28)
   end
 
   love.graphics.setScissor()

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -4,6 +4,7 @@ local InfluenceLayout = require("ui.layout.influence_layout")
 
 local ObjectivesPanel = require("ui.components.objectives_panel")
 local InfluenceExplain = require("ui.components.influence_explain")
+local HazardCard = require("ui.components.hazard_card")
 
 local RuntimeInfluence = {}
 RuntimeInfluence.__index = RuntimeInfluence
@@ -151,13 +152,13 @@ function RuntimeInfluence:draw_diamond(x, y, size, fill_color, border_color)
   end
 end
 
-function RuntimeInfluence:draw_stat_track(map_rect, node, stat_key, current_value, preview_value, target_value)
+function RuntimeInfluence:draw_stat_track(map_graph_rect, node, stat_key, current_value, preview_value, target_value)
   local bounds = self.ctx.terraforming_state:get_stat_bounds(stat_key)
   local track_w = math.floor(node.r * 1.6)
   local track_h = 12
   local track_x = math.floor(node.x - (track_w * 0.5))
   local track_y = math.floor(node.y - node.r - 20)
-  local min_track_y = map_rect.y + 86
+  local min_track_y = map_graph_rect.y + 8
   if track_y < min_track_y then
     track_y = min_track_y
   end
@@ -200,8 +201,105 @@ function RuntimeInfluence:draw_stat_track(map_rect, node, stat_key, current_valu
   end
 end
 
+function RuntimeInfluence:draw_magnetosphere_field(layout)
+  local magnetosphere = layout.magnetosphere
+  if not magnetosphere then
+    return
+  end
+
+  local mag_level = self.ctx.terraforming_state:get_magnetosphere_level()
+  local strength = self.ctx:clamp_value((mag_level - 1) / 3, 0, 1)
+  local cx = magnetosphere.x
+  local cy = magnetosphere.y
+  local base_r = magnetosphere.base_r
+
+  love.graphics.push()
+  love.graphics.translate(cx, cy)
+
+  for i = 1, 5 do
+    local t = i / 5
+    local radius = base_r + (i - 1) * 18
+    local stretch = 1.0 + t * 0.55
+    local alpha = (0.05 + strength * 0.05) * (1.0 - t * 0.25)
+    love.graphics.push()
+    love.graphics.scale(stretch, 1)
+    love.graphics.setColor(0.38, 0.68, 1.0, alpha)
+    love.graphics.circle("line", 0, 0, radius)
+    love.graphics.pop()
+  end
+
+  for i = 1, 3 do
+    local radius = base_r + 46 + i * 16
+    local warm_alpha = 0.03 + (1.0 - strength) * 0.05
+    love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha)
+    love.graphics.arc("line", "open", math.pi * 0.73, math.pi * 1.27, radius)
+  end
+
+  love.graphics.pop()
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+function RuntimeInfluence:draw_incoming_hazard_panel(layout)
+  local hazard_rect = layout.hazard_rect
+  local hazard_card_rect = layout.hazard_card_rect
+  if not hazard_rect or not hazard_card_rect then
+    return
+  end
+
+  local projection = self.ctx.terraforming_state:preview_next_hazard()
+  local hazard = projection.hazard or {}
+  local mag_level = self.ctx.terraforming_state:get_magnetosphere_level()
+  local mag_tier = self.ctx.terraforming_state:get_magnetosphere_tier(mag_level)
+  local pulse = 0.5 + 0.5 * math.sin(love.timer.getTime() * 3.1)
+
+  love.graphics.setColor(0.06, 0.08, 0.12, 0.9)
+  love.graphics.rectangle("fill", hazard_rect.x, hazard_rect.y, hazard_rect.w, hazard_rect.h, 10, 10)
+  love.graphics.setColor(0.72, 0.82, 0.96, 1)
+  love.graphics.rectangle("line", hazard_rect.x, hazard_rect.y, hazard_rect.w, hazard_rect.h, 10, 10)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.printf("Incoming Hazard", hazard_rect.x + 10, hazard_rect.y + 10, hazard_rect.w - 20, "left")
+  love.graphics.setColor(0.75, 0.87, 0.95, 1)
+  love.graphics.printf(
+    "Magnetosphere L" .. tostring(mag_level) .. " (" .. mag_tier .. ")",
+    hazard_rect.x + 10,
+    hazard_rect.y + 30,
+    hazard_rect.w - 20,
+    "left"
+  )
+
+  HazardCard.draw({
+    rect = hazard_card_rect,
+    projection = projection,
+    target = {
+      x = layout.magnetosphere.x,
+      y = layout.magnetosphere.y,
+      radius = math.floor(layout.magnetosphere.base_r * 0.62)
+    },
+    pulse = pulse,
+    format_delta_list = function(deltas)
+      return self.ctx:format_delta_list(deltas)
+    end,
+    magnetosphere_level = mag_level,
+    magnetosphere_tier = mag_tier
+  })
+
+  local footer_y = hazard_rect.y + hazard_rect.h - 44
+  local footer_text
+  if hazard.magnetosphere_blockable then
+    footer_text = "After block: " .. self.ctx:format_delta_list(projection.effective_deltas)
+    love.graphics.setColor(0.7, 0.9, 1.0, 1)
+  else
+    footer_text = "Bypasses magnetosphere"
+    love.graphics.setColor(0.93, 0.8, 0.42, 1)
+  end
+  love.graphics.printf(footer_text, hazard_rect.x + 10, footer_y, hazard_rect.w - 20, "left")
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
 function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   local map_rect = layout.map_rect
+  local graph_rect = layout.map_graph_rect
   local snapshot = forecast_ctx.active_snapshot
   local toggle_buttons = self:get_map_toggle_buttons(layout)
   local projection_label = "Viewing Current State"
@@ -215,10 +313,14 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   love.graphics.rectangle("line", map_rect.x, map_rect.y, map_rect.w, map_rect.h, 10, 10)
 
   love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.printf("Core Influence Graph", map_rect.x + 12, map_rect.y + 10, map_rect.w - 24, "left")
-  love.graphics.printf("Use Explain Graph for detailed coupling rules and focused primitive breakdown.", map_rect.x + 12, map_rect.y + 30, map_rect.w - 24, "left")
+  local font_h = love.graphics.getFont():getHeight()
+  local title_y = map_rect.y + 10
+  local subtitle_y = title_y + font_h + 2
+  local projection_y = subtitle_y + font_h + 2
+  love.graphics.printf("Core Influence Graph", map_rect.x + 12, title_y, map_rect.w - 24, "left")
+  love.graphics.printf("Use Explain Graph for detailed coupling rules and focused primitive breakdown.", map_rect.x + 12, subtitle_y, map_rect.w - 24, "left")
   love.graphics.setColor(0.75, 0.87, 0.95, 1)
-  love.graphics.printf(projection_label, map_rect.x + 12, map_rect.y + 48, map_rect.w - 24, "left")
+  love.graphics.printf(projection_label, map_rect.x + 12, projection_y, map_rect.w - 24, "left")
 
   local filter_fill = self.ctx.influence_ui.hovered_edge_filter_button and { 0.2, 0.3, 0.4, 0.95 } or { 0.14, 0.19, 0.27, 0.95 }
   love.graphics.setColor(unpack(filter_fill))
@@ -240,26 +342,30 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.printf(self.ctx.influence_ui.show_graph_explain and "Hide Graph" or "Explain Graph", toggle_buttons.explain_graph.x + 4, toggle_buttons.explain_graph.y + 6, toggle_buttons.explain_graph.w - 8, "center")
 
-  love.graphics.setColor(0.45, 0.95, 0.45, 1)
-  love.graphics.circle("fill", map_rect.x + 18, map_rect.y + 58, 7)
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("+ target impact", map_rect.x + 30, map_rect.y + 51)
-  love.graphics.setColor(0.98, 0.45, 0.45, 1)
-  love.graphics.circle("fill", map_rect.x + 156, map_rect.y + 58, 7)
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("- target impact", map_rect.x + 168, map_rect.y + 51)
-  love.graphics.setColor(0.62, 0.66, 0.74, 1)
-  love.graphics.circle("fill", map_rect.x + 292, map_rect.y + 58, 7)
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("0 neutral", map_rect.x + 304, map_rect.y + 51)
+  local legend_row1_y = projection_y + font_h + 6
+  local legend_row2_y = legend_row1_y + font_h + 4
 
-  local marker_legend_y = map_rect.y + 68
-  self:draw_diamond(map_rect.x + 18, marker_legend_y + 1, 5, { 1, 1, 1, 1 }, { 0.05, 0.08, 0.12, 1 })
+  love.graphics.setColor(0.45, 0.95, 0.45, 1)
+  love.graphics.circle("fill", map_rect.x + 18, legend_row1_y + 7)
   love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("current", map_rect.x + 30, marker_legend_y - 6)
-  self:draw_diamond(map_rect.x + 124, marker_legend_y + 1, 5, { 0.45, 0.78, 1.0, 1 }, { 0.05, 0.08, 0.12, 1 })
+  love.graphics.print("+ target impact", map_rect.x + 30, legend_row1_y)
+  love.graphics.setColor(0.98, 0.45, 0.45, 1)
+  love.graphics.circle("fill", map_rect.x + 166, legend_row1_y + 7)
   love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.print("preview (card push)", map_rect.x + 136, marker_legend_y - 6)
+  love.graphics.print("- target impact", map_rect.x + 178, legend_row1_y)
+  love.graphics.setColor(0.62, 0.66, 0.74, 1)
+  love.graphics.circle("fill", map_rect.x + 314, legend_row1_y + 7)
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.print("0 neutral", map_rect.x + 326, legend_row1_y)
+
+  self:draw_diamond(map_rect.x + 18, legend_row2_y + 8, 5, { 1, 1, 1, 1 }, { 0.05, 0.08, 0.12, 1 })
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.print("current", map_rect.x + 30, legend_row2_y + 1)
+  self:draw_diamond(map_rect.x + 124, legend_row2_y + 8, 5, { 0.45, 0.78, 1.0, 1 }, { 0.05, 0.08, 0.12, 1 })
+  love.graphics.setColor(1, 1, 1, 1)
+  love.graphics.print("preview (card push)", map_rect.x + 136, legend_row2_y + 1)
+
+  self:draw_magnetosphere_field(layout)
 
   for _, edge in ipairs(self.ctx.INFLUENCE_EDGES) do
     if self:edge_is_visible(edge) then
@@ -283,7 +389,7 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
     local is_focused = key == self.ctx.influence_ui.focused_stat
     local is_hovered = key == self.ctx.influence_ui.hovered_influence_stat
 
-    self:draw_stat_track(map_rect, node, key, current_value, preview_value, self.ctx.terraforming_state.targets[key])
+    self:draw_stat_track(graph_rect, node, key, current_value, preview_value, self.ctx.terraforming_state.targets[key])
 
     love.graphics.setColor(0.08, 0.1, 0.14, 0.95)
     love.graphics.circle("fill", node.x, node.y, node.r)
@@ -476,6 +582,7 @@ function RuntimeInfluence:draw_influence_screen()
   love.graphics.print("Use Explain Graph, Explain Next Turn, and Explain Objectives for detailed breakdowns.", heading_x, heading_y + 40)
   love.graphics.print("M mapping, C clear card, I flow, Z current, X do nothing, P selected card, V gameplay.", heading_x, heading_y + 60)
 
+  self:draw_incoming_hazard_panel(layout)
   self:draw_influence_nodes(layout, forecast_ctx)
   self:draw_end_objectives_panel(layout, forecast_ctx)
   if self.ctx.influence_ui.show_graph_explain then

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -9,6 +9,20 @@ local HazardCard = require("ui.components.hazard_card")
 local RuntimeInfluence = {}
 RuntimeInfluence.__index = RuntimeInfluence
 
+local function draw_arc_polyline(cx, cy, rx, ry, start_angle, end_angle, segments)
+  segments = math.max(8, segments or 18)
+  local points = {}
+  for i = 0, segments do
+    local t = i / segments
+    local angle = start_angle + (end_angle - start_angle) * t
+    points[#points + 1] = cx + math.cos(angle) * rx
+    points[#points + 1] = cy + math.sin(angle) * ry
+  end
+  if #points >= 4 then
+    love.graphics.line(points)
+  end
+end
+
 function RuntimeInfluence.new(ctx)
   return setmetatable({ ctx = ctx }, RuntimeInfluence)
 end
@@ -203,7 +217,8 @@ end
 
 function RuntimeInfluence:draw_magnetosphere_field(layout)
   local magnetosphere = layout.magnetosphere
-  if not magnetosphere then
+  local graph_rect = layout.map_graph_rect
+  if not magnetosphere or not graph_rect then
     return
   end
 
@@ -213,29 +228,48 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
   local cy = magnetosphere.y
   local base_r = magnetosphere.base_r
 
-  love.graphics.push()
-  love.graphics.translate(cx, cy)
+  local line_width = love.graphics.getLineWidth()
+  local left_center_x = cx - base_r * 0.1
+  local right_center_x = cx + base_r * 0.14
+  local left_rx_base = base_r * 0.44
+  local left_ry_base = base_r * 0.82
+  local right_rx_base = base_r * 1.02
+  local right_ry_base = base_r * 0.76
+
+  love.graphics.setScissor(graph_rect.x + 2, graph_rect.y + 2, graph_rect.w - 4, graph_rect.h - 4)
 
   for i = 1, 5 do
-    local t = i / 5
-    local radius = base_r + (i - 1) * 18
-    local stretch = 1.0 + t * 0.55
-    local alpha = (0.05 + strength * 0.05) * (1.0 - t * 0.25)
-    love.graphics.push()
-    love.graphics.scale(stretch, 1)
-    love.graphics.setColor(0.38, 0.68, 1.0, alpha)
-    love.graphics.circle("line", 0, 0, radius)
-    love.graphics.pop()
+    local t = (i - 1) / 4
+    local alpha = (0.04 + strength * 0.06) * (1.0 - t * 0.2)
+    local rx = left_rx_base + i * 12
+    local ry = left_ry_base + i * 10
+    love.graphics.setColor(0.36, 0.67, 1.0, alpha)
+    love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
+    draw_arc_polyline(left_center_x, cy, rx, ry, math.rad(118), math.rad(242), 24)
   end
 
+  for i = 1, 5 do
+    local t = (i - 1) / 4
+    local alpha = (0.035 + strength * 0.05) * (1.0 - t * 0.18)
+    local rx = right_rx_base + i * (20 + strength * 7)
+    local ry = right_ry_base + i * 12
+    love.graphics.setColor(0.35, 0.62, 0.98, alpha)
+    love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
+    draw_arc_polyline(right_center_x, cy, rx, ry, math.rad(-62), math.rad(62), 28)
+  end
+
+  local warm_alpha = 0.02 + (1.0 - strength) * 0.055
   for i = 1, 3 do
-    local radius = base_r + 46 + i * 16
-    local warm_alpha = 0.03 + (1.0 - strength) * 0.05
-    love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha)
-    love.graphics.arc("line", "open", 0, 0, radius, math.pi * 0.73, math.pi * 1.27)
+    local fade = 1 - (i - 1) * 0.22
+    local rx = left_rx_base + base_r * 0.25 + i * 16
+    local ry = left_ry_base + i * 14
+    love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha * fade)
+    love.graphics.setLineWidth(1.2)
+    draw_arc_polyline(left_center_x - base_r * 0.04, cy, rx, ry, math.rad(126), math.rad(234), 22)
   end
 
-  love.graphics.pop()
+  love.graphics.setScissor()
+  love.graphics.setLineWidth(line_width)
   love.graphics.setColor(1, 1, 1, 1)
 end
 
@@ -247,7 +281,6 @@ function RuntimeInfluence:draw_incoming_hazard_panel(layout)
   end
 
   local projection = self.ctx.terraforming_state:preview_next_hazard()
-  local hazard = projection.hazard or {}
   local mag_level = self.ctx.terraforming_state:get_magnetosphere_level()
   local mag_tier = self.ctx.terraforming_state:get_magnetosphere_tier(mag_level)
   local pulse = 0.5 + 0.5 * math.sin(love.timer.getTime() * 3.1)
@@ -259,14 +292,6 @@ function RuntimeInfluence:draw_incoming_hazard_panel(layout)
 
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.printf("Incoming Hazard", hazard_rect.x + 10, hazard_rect.y + 10, hazard_rect.w - 20, "left")
-  love.graphics.setColor(0.75, 0.87, 0.95, 1)
-  love.graphics.printf(
-    "Magnetosphere L" .. tostring(mag_level) .. " (" .. mag_tier .. ")",
-    hazard_rect.x + 10,
-    hazard_rect.y + 30,
-    hazard_rect.w - 20,
-    "left"
-  )
 
   HazardCard.draw({
     rect = hazard_card_rect,
@@ -283,18 +308,6 @@ function RuntimeInfluence:draw_incoming_hazard_panel(layout)
     magnetosphere_level = mag_level,
     magnetosphere_tier = mag_tier
   })
-
-  local footer_y = hazard_rect.y + hazard_rect.h - 44
-  local footer_text
-  if hazard.magnetosphere_blockable then
-    footer_text = "After block: " .. self.ctx:format_delta_list(projection.effective_deltas)
-    love.graphics.setColor(0.7, 0.9, 1.0, 1)
-  else
-    footer_text = "Bypasses magnetosphere"
-    love.graphics.setColor(0.93, 0.8, 0.42, 1)
-  end
-  love.graphics.printf(footer_text, hazard_rect.x + 10, footer_y, hazard_rect.w - 20, "left")
-  love.graphics.setColor(1, 1, 1, 1)
 end
 
 function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -218,49 +218,63 @@ end
 function RuntimeInfluence:draw_magnetosphere_field(layout)
   local magnetosphere = layout.magnetosphere
   local graph_rect = layout.map_graph_rect
-  if not magnetosphere or not graph_rect then
+  if not magnetosphere or not graph_rect or not layout.nodes then
     return
   end
 
   local mag_level = self.ctx.terraforming_state:get_magnetosphere_level()
   local strength = self.ctx:clamp_value((mag_level - 1) / 3, 0, 1)
-  local cx = magnetosphere.x
   local cy = magnetosphere.y
-  local base_r = magnetosphere.base_r
+  local left_bound = layout.nodes.air.x - layout.nodes.air.r
+  local right_bound = layout.nodes.water.x + layout.nodes.water.r
+  local top_bound = layout.nodes.heat.y - layout.nodes.heat.r
+  local bottom_bound = layout.nodes.soil.y + layout.nodes.soil.r
+  local cluster_h = math.max(120, bottom_bound - top_bound)
+  local graph_right = graph_rect.x + graph_rect.w - 12
 
   local line_width = love.graphics.getLineWidth()
 
   love.graphics.setScissor(graph_rect.x + 2, graph_rect.y + 2, graph_rect.w - 4, graph_rect.h - 4)
 
+  -- Dayside (left): compressed bow lines kept outside the air node.
   for i = 1, 5 do
     local t = (i - 1) / 4
-    local alpha = (0.03 + strength * 0.05) * (1.0 - t * 0.18)
-    local shell = base_r + (i - 1) * 14
-    local rx = shell * 0.82
-    local ry = shell * 0.96
+    local alpha = (0.022 + strength * 0.04) * (1.0 - t * 0.18)
+    local rx = 22 + i * 9
+    local ry = cluster_h * 0.52 + i * 10
+    local cx = left_bound - (44 + i * 7)
+    if cx + rx > left_bound - 8 then
+      cx = (left_bound - 8) - rx
+    end
     love.graphics.setColor(0.36, 0.67, 1.0, alpha)
     love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
     draw_arc_polyline(cx, cy, rx, ry, math.rad(112), math.rad(248), 26)
   end
 
+  -- Nightside (right): stretched tail lines, capped to graph bounds.
   for i = 1, 5 do
     local t = (i - 1) / 4
-    local alpha = (0.032 + strength * 0.05) * (1.0 - t * 0.16)
-    local shell = base_r + i * 18
-    local rx = shell * (1.16 + strength * 0.18)
-    local ry = shell * 0.74
-    local tail_cx = cx + base_r * 0.28 + i * 5
+    local alpha = (0.03 + strength * 0.045) * (1.0 - t * 0.16)
+    local tail_cx = right_bound + 8 + i * 2
+    local target_rx = 64 + i * 14 + strength * 14
+    local max_rx = math.max(20, graph_right - tail_cx)
+    local rx = math.min(target_rx, max_rx)
+    local ry = cluster_h * 0.44 + i * 8
     love.graphics.setColor(0.35, 0.62, 0.98, alpha)
     love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
     draw_arc_polyline(tail_cx, cy, rx, ry, math.rad(-58), math.rad(58), 30)
   end
 
+  -- Bow shock accent in front of the compressed side.
   local warm_alpha = 0.02 + (1.0 - strength) * 0.055
-  for i = 1, 3 do
+  for i = 1, 2 do
     local fade = 1 - (i - 1) * 0.22
-    local shock_cx = cx - base_r * 0.86
-    local rx = base_r * 0.58 + i * 14
-    local ry = base_r * 0.98 + i * 20
+    local rx = 44 + i * 14
+    local ry = cluster_h * 0.66 + i * 16
+    local shock_cx = left_bound - (78 + i * 14)
+    if shock_cx + rx > left_bound - 20 then
+      shock_cx = (left_bound - 20) - rx
+    end
     love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha * fade)
     love.graphics.setLineWidth(1.2)
     draw_arc_polyline(shock_cx, cy, rx, ry, math.rad(106), math.rad(254), 24)

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -232,7 +232,7 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
     local radius = base_r + 46 + i * 16
     local warm_alpha = 0.03 + (1.0 - strength) * 0.05
     love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha)
-    love.graphics.arc("line", "open", math.pi * 0.73, math.pi * 1.27, radius)
+    love.graphics.arc("line", "open", 0, 0, radius, math.pi * 0.73, math.pi * 1.27)
   end
 
   love.graphics.pop()

--- a/app/runtime_influence.lua
+++ b/app/runtime_influence.lua
@@ -229,43 +229,41 @@ function RuntimeInfluence:draw_magnetosphere_field(layout)
   local base_r = magnetosphere.base_r
 
   local line_width = love.graphics.getLineWidth()
-  local left_center_x = cx - base_r * 0.1
-  local right_center_x = cx + base_r * 0.14
-  local left_rx_base = base_r * 0.44
-  local left_ry_base = base_r * 0.82
-  local right_rx_base = base_r * 1.02
-  local right_ry_base = base_r * 0.76
 
   love.graphics.setScissor(graph_rect.x + 2, graph_rect.y + 2, graph_rect.w - 4, graph_rect.h - 4)
 
   for i = 1, 5 do
     local t = (i - 1) / 4
-    local alpha = (0.04 + strength * 0.06) * (1.0 - t * 0.2)
-    local rx = left_rx_base + i * 12
-    local ry = left_ry_base + i * 10
+    local alpha = (0.03 + strength * 0.05) * (1.0 - t * 0.18)
+    local shell = base_r + (i - 1) * 14
+    local rx = shell * 0.82
+    local ry = shell * 0.96
     love.graphics.setColor(0.36, 0.67, 1.0, alpha)
     love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
-    draw_arc_polyline(left_center_x, cy, rx, ry, math.rad(118), math.rad(242), 24)
+    draw_arc_polyline(cx, cy, rx, ry, math.rad(112), math.rad(248), 26)
   end
 
   for i = 1, 5 do
     local t = (i - 1) / 4
-    local alpha = (0.035 + strength * 0.05) * (1.0 - t * 0.18)
-    local rx = right_rx_base + i * (20 + strength * 7)
-    local ry = right_ry_base + i * 12
+    local alpha = (0.032 + strength * 0.05) * (1.0 - t * 0.16)
+    local shell = base_r + i * 18
+    local rx = shell * (1.16 + strength * 0.18)
+    local ry = shell * 0.74
+    local tail_cx = cx + base_r * 0.28 + i * 5
     love.graphics.setColor(0.35, 0.62, 0.98, alpha)
     love.graphics.setLineWidth(math.max(1, 1.6 - t * 0.4))
-    draw_arc_polyline(right_center_x, cy, rx, ry, math.rad(-62), math.rad(62), 28)
+    draw_arc_polyline(tail_cx, cy, rx, ry, math.rad(-58), math.rad(58), 30)
   end
 
   local warm_alpha = 0.02 + (1.0 - strength) * 0.055
   for i = 1, 3 do
     local fade = 1 - (i - 1) * 0.22
-    local rx = left_rx_base + base_r * 0.25 + i * 16
-    local ry = left_ry_base + i * 14
+    local shock_cx = cx - base_r * 0.86
+    local rx = base_r * 0.58 + i * 14
+    local ry = base_r * 0.98 + i * 20
     love.graphics.setColor(0.96, 0.55, 0.25, warm_alpha * fade)
     love.graphics.setLineWidth(1.2)
-    draw_arc_polyline(left_center_x - base_r * 0.04, cy, rx, ry, math.rad(126), math.rad(234), 22)
+    draw_arc_polyline(shock_cx, cy, rx, ry, math.rad(106), math.rad(254), 24)
   end
 
   love.graphics.setScissor()
@@ -306,7 +304,8 @@ function RuntimeInfluence:draw_incoming_hazard_panel(layout)
       return self.ctx:format_delta_list(deltas)
     end,
     magnetosphere_level = mag_level,
-    magnetosphere_tier = mag_tier
+    magnetosphere_tier = mag_tier,
+    show_target_vector = false
   })
 end
 
@@ -315,6 +314,8 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   local graph_rect = layout.map_graph_rect
   local snapshot = forecast_ctx.active_snapshot
   local toggle_buttons = self:get_map_toggle_buttons(layout)
+  local mag_level = self.ctx.terraforming_state:get_magnetosphere_level()
+  local mag_tier = self.ctx.terraforming_state:get_magnetosphere_tier(mag_level)
   local projection_label = "Viewing Current State"
   if forecast_ctx.active_mode ~= "current" then
     projection_label = "Viewing End-Turn Projection"
@@ -334,6 +335,9 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   love.graphics.printf("Use Explain Graph for detailed coupling rules and focused primitive breakdown.", map_rect.x + 12, subtitle_y, map_rect.w - 24, "left")
   love.graphics.setColor(0.75, 0.87, 0.95, 1)
   love.graphics.printf(projection_label, map_rect.x + 12, projection_y, map_rect.w - 24, "left")
+  local magnetosphere_y = projection_y + font_h + 2
+  love.graphics.setColor(0.68, 0.87, 1.0, 1)
+  love.graphics.printf("Magnetosphere: L" .. tostring(mag_level) .. " (" .. mag_tier .. ")", map_rect.x + 12, magnetosphere_y, map_rect.w - 24, "left")
 
   local filter_fill = self.ctx.influence_ui.hovered_edge_filter_button and { 0.2, 0.3, 0.4, 0.95 } or { 0.14, 0.19, 0.27, 0.95 }
   love.graphics.setColor(unpack(filter_fill))
@@ -355,7 +359,7 @@ function RuntimeInfluence:draw_influence_nodes(layout, forecast_ctx)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.printf(self.ctx.influence_ui.show_graph_explain and "Hide Graph" or "Explain Graph", toggle_buttons.explain_graph.x + 4, toggle_buttons.explain_graph.y + 6, toggle_buttons.explain_graph.w - 8, "center")
 
-  local legend_row1_y = projection_y + font_h + 6
+  local legend_row1_y = magnetosphere_y + font_h + 6
   local legend_row2_y = legend_row1_y + font_h + 4
 
   love.graphics.setColor(0.45, 0.95, 0.45, 1)

--- a/tests/gameplay_layout_spec.lua
+++ b/tests/gameplay_layout_spec.lua
@@ -47,7 +47,7 @@ local function run_baseline_geometry_contract()
   local hand = GameplayLayout.get_hand_layout(safe, 5, hand_ui)
   local deck = GameplayLayout.get_deck_rect(safe, pile_ui)
   local discard = GameplayLayout.get_discard_rect(safe, pile_ui)
-  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, hand_ui, end_turn_ui)
+  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, hand_ui, end_turn_ui, pile_ui)
   local hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
   add_log(result, "WHEN computing gameplay positions")
 
@@ -62,13 +62,14 @@ local function run_baseline_geometry_contract()
   expect_equal(result, "deck y", deck.y, 646)
   expect_equal(result, "discard x", discard.x, 1526)
   expect_equal(result, "discard y", discard.y, 646)
-  expect_equal(result, "end turn x", end_turn.x, 1446)
-  expect_equal(result, "end turn y", end_turn.y, 616)
+  expect_equal(result, "end turn x", end_turn.x, 1448)
+  expect_equal(result, "end turn y", end_turn.y, 582)
+  expect_equal(result, "end turn sits above discard", end_turn.y + end_turn.h < discard.y, true)
 
-  expect_near(result, "hazard x", hazard.x, 833.92, 0.001)
-  expect_near(result, "hazard y", hazard.y, 216.72, 0.001)
-  expect_equal(result, "hazard width", hazard.w, 132)
-  expect_equal(result, "hazard height", hazard.h, 170)
+  expect_near(result, "hazard x", hazard.x, 795.92, 0.001)
+  expect_near(result, "hazard y", hazard.y, 193.72, 0.001)
+  expect_equal(result, "hazard width", hazard.w, 170)
+  expect_equal(result, "hazard height", hazard.h, 236)
   return result
 end
 
@@ -82,9 +83,9 @@ local function run_hazard_clamp_contract()
   add_log(result, "WHEN hazard rect is clamped inside safe bounds")
 
   expect_equal(result, "hazard x clamps to min inset", hazard.x, 16)
-  expect_equal(result, "hazard y clamps to max inset", hazard.y, 74)
-  expect_equal(result, "hazard width fixed", hazard.w, 132)
-  expect_equal(result, "hazard height fixed", hazard.h, 170)
+  expect_equal(result, "hazard y clamps to max inset", hazard.y, 8)
+  expect_equal(result, "hazard width fixed", hazard.w, 170)
+  expect_equal(result, "hazard height fixed", hazard.h, 236)
   return result
 end
 
@@ -104,7 +105,7 @@ local function run_compute_parity_contract()
   local hand = GameplayLayout.get_hand_layout(safe, ui_state.hand_count, ui_state.hand_ui)
   local deck = GameplayLayout.get_deck_rect(safe, ui_state.pile_ui)
   local discard = GameplayLayout.get_discard_rect(safe, ui_state.pile_ui)
-  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, ui_state.hand_ui, ui_state.end_turn_ui)
+  local end_turn = GameplayLayout.get_end_turn_rect(safe, hand, ui_state.hand_ui, ui_state.end_turn_ui, ui_state.pile_ui)
   local hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
   add_log(result, "WHEN comparing compute output to helper outputs")
 

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -31,10 +31,10 @@ local function run_compute_contract()
   add_log(result, "WHEN computing influence layout panels and nodes")
 
   expect_equal(result, "hazard x anchors to safe left", layout.hazard_rect.x, safe.x)
-  expect_equal(result, "hazard y offset", layout.hazard_rect.y, safe.y + 50)
+  expect_equal(result, "hazard y offset", layout.hazard_rect.y, safe.y + 44)
   expect_equal(result, "hazard width ratio floor", layout.hazard_rect.w, math.max(220, math.floor(safe.w * 0.18)))
 
-  local expected_cards_h = math.max(170, math.min(196, math.floor(safe.h * 0.24)))
+  local expected_cards_h = math.max(150, math.min(170, math.floor(safe.h * 0.20)))
   expect_equal(result, "cards fixed compact height", layout.cards_rect.h, expected_cards_h)
   expect_equal(result, "cards pinned to safe bottom", layout.cards_rect.y, safe.y + safe.h - expected_cards_h)
 
@@ -44,7 +44,7 @@ local function run_compute_contract()
 
   local expected_map_x = layout.hazard_rect.x + layout.hazard_rect.w + 14
   expect_equal(result, "map x follows hazard + gap", layout.map_rect.x, expected_map_x)
-  expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 50)
+  expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 44)
   expect_equal(result, "map width uses remainder split", layout.map_rect.w, safe.w - layout.hazard_rect.w - layout.objectives_rect.w - 28)
 
   local right_x = layout.map_rect.x + layout.map_rect.w + 14
@@ -53,9 +53,9 @@ local function run_compute_contract()
   expect_equal(result, "cards span full safe width", layout.cards_rect.w, safe.w)
 
   expect_equal(result, "graph rect is inset inside map panel", layout.map_graph_rect.x, layout.map_rect.x + 14)
-  expect_equal(result, "graph rect y offset", layout.map_graph_rect.y, layout.map_rect.y + 132)
+  expect_equal(result, "graph rect y offset", layout.map_graph_rect.y, layout.map_rect.y + 118)
   expect_equal(result, "graph rect width inset", layout.map_graph_rect.w, layout.map_rect.w - 28)
-  expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 176)
+  expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 162)
 
   expect_equal(result, "hazard card width cap", layout.hazard_card_rect.w, math.min(layout.hazard_rect.w - 20, 236))
   local expected_hazard_card_h = math.max(190, math.min(layout.hazard_rect.h - 62, 266))

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -31,7 +31,7 @@ local function run_compute_contract()
   add_log(result, "WHEN computing influence layout panels and nodes")
 
   expect_equal(result, "hazard x anchors to safe left", layout.hazard_rect.x, safe.x)
-  expect_equal(result, "hazard y offset", layout.hazard_rect.y, safe.y + 76)
+  expect_equal(result, "hazard y offset", layout.hazard_rect.y, safe.y + 50)
   expect_equal(result, "hazard width ratio floor", layout.hazard_rect.w, math.max(220, math.floor(safe.w * 0.18)))
 
   local expected_cards_h = math.max(170, math.min(196, math.floor(safe.h * 0.24)))
@@ -44,7 +44,7 @@ local function run_compute_contract()
 
   local expected_map_x = layout.hazard_rect.x + layout.hazard_rect.w + 14
   expect_equal(result, "map x follows hazard + gap", layout.map_rect.x, expected_map_x)
-  expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 76)
+  expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 50)
   expect_equal(result, "map width uses remainder split", layout.map_rect.w, safe.w - layout.hazard_rect.w - layout.objectives_rect.w - 28)
 
   local right_x = layout.map_rect.x + layout.map_rect.w + 14
@@ -81,6 +81,7 @@ local function run_controls_contract()
   add_log(result, "GIVEN computed influence layout")
   local toggles = InfluenceLayout.get_map_toggle_buttons(layout)
   local mode_buttons = InfluenceLayout.get_forecast_mode_buttons(layout.turn_explain_rect)
+  local help_button = InfluenceLayout.get_help_button(layout)
   local preview_button = InfluenceLayout.get_preview_explain_button(layout)
   local objectives_button = InfluenceLayout.get_objectives_explain_button(layout)
   add_log(result, "WHEN resolving button geometry")
@@ -89,7 +90,10 @@ local function run_controls_contract()
   expect_equal(result, "map explain button width", toggles.explain_graph.w, 154)
   expect_equal(result, "single forecast mode button currently available", #mode_buttons, 1)
   expect_equal(result, "forecast button id", mode_buttons[1].id, "current")
+  expect_equal(result, "help button width", help_button.w, 24)
+  expect_equal(result, "help button is left of preview explain", help_button.x, layout.cards_rect.x + 12)
   expect_equal(result, "preview explain button width", preview_button.w, 176)
+  expect_equal(result, "preview explain button shifted for help icon", preview_button.x, layout.cards_rect.x + 44)
   expect_equal(result, "objectives explain button width", objectives_button.w, 188)
   expect_equal(result, "graph explain button remains in map footer", toggles.explain_graph.y, layout.map_rect.y + layout.map_rect.h - 34)
   return result

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -58,7 +58,13 @@ local function run_compute_contract()
   expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 164)
 
   expect_equal(result, "hazard card width cap", layout.hazard_card_rect.w, math.min(layout.hazard_rect.w - 20, 236))
-  expect_equal(result, "hazard card height cap", layout.hazard_card_rect.h, math.min(layout.hazard_rect.h - 42, 276))
+  local expected_hazard_card_h = math.max(190, math.min(layout.hazard_rect.h - 62, 266))
+  local expected_hazard_card_y = layout.hazard_rect.y + 42
+  local expected_hazard_bottom = layout.hazard_rect.y + layout.hazard_rect.h - 10
+  if expected_hazard_card_y + expected_hazard_card_h > expected_hazard_bottom then
+    expected_hazard_card_h = math.max(160, expected_hazard_bottom - expected_hazard_card_y)
+  end
+  expect_equal(result, "hazard card height cap", layout.hazard_card_rect.h, expected_hazard_card_h)
 
   expect_equal(result, "heat and soil share x", layout.nodes.heat.x, layout.nodes.soil.x)
   expect_equal(result, "air and water share y", layout.nodes.air.y, layout.nodes.water.y)

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -53,9 +53,9 @@ local function run_compute_contract()
   expect_equal(result, "cards span full safe width", layout.cards_rect.w, safe.w)
 
   expect_equal(result, "graph rect is inset inside map panel", layout.map_graph_rect.x, layout.map_rect.x + 14)
-  expect_equal(result, "graph rect y offset", layout.map_graph_rect.y, layout.map_rect.y + 120)
+  expect_equal(result, "graph rect y offset", layout.map_graph_rect.y, layout.map_rect.y + 132)
   expect_equal(result, "graph rect width inset", layout.map_graph_rect.w, layout.map_rect.w - 28)
-  expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 164)
+  expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 176)
 
   expect_equal(result, "hazard card width cap", layout.hazard_card_rect.w, math.min(layout.hazard_rect.w - 20, 236))
   local expected_hazard_card_h = math.max(190, math.min(layout.hazard_rect.h - 62, 266))

--- a/tests/influence_layout_spec.lua
+++ b/tests/influence_layout_spec.lua
@@ -30,20 +30,41 @@ local function run_compute_contract()
   local layout = InfluenceLayout.compute(safe)
   add_log(result, "WHEN computing influence layout panels and nodes")
 
-  expect_equal(result, "map x", layout.map_rect.x, safe.x)
+  expect_equal(result, "hazard x anchors to safe left", layout.hazard_rect.x, safe.x)
+  expect_equal(result, "hazard y offset", layout.hazard_rect.y, safe.y + 76)
+  expect_equal(result, "hazard width ratio floor", layout.hazard_rect.w, math.max(220, math.floor(safe.w * 0.18)))
+
+  local expected_cards_h = math.max(170, math.min(196, math.floor(safe.h * 0.24)))
+  expect_equal(result, "cards fixed compact height", layout.cards_rect.h, expected_cards_h)
+  expect_equal(result, "cards pinned to safe bottom", layout.cards_rect.y, safe.y + safe.h - expected_cards_h)
+
+  local expected_top_h = layout.cards_rect.y - layout.hazard_rect.y - 12
+  expect_equal(result, "hazard and top panels share computed top height", layout.hazard_rect.h, expected_top_h)
+  expect_equal(result, "map panel shares top height", layout.map_rect.h, expected_top_h)
+
+  local expected_map_x = layout.hazard_rect.x + layout.hazard_rect.w + 14
+  expect_equal(result, "map x follows hazard + gap", layout.map_rect.x, expected_map_x)
   expect_equal(result, "map y offset", layout.map_rect.y, safe.y + 76)
-  expect_equal(result, "map width ratio", layout.map_rect.w, math.floor(safe.w * 0.54))
-  expect_equal(result, "map height ratio", layout.map_rect.h, math.floor(safe.h * 0.62))
+  expect_equal(result, "map width uses remainder split", layout.map_rect.w, safe.w - layout.hazard_rect.w - layout.objectives_rect.w - 28)
 
   local right_x = layout.map_rect.x + layout.map_rect.w + 14
   expect_equal(result, "objectives x follows map + gap", layout.objectives_rect.x, right_x)
   expect_equal(result, "objectives width fills remaining space", layout.objectives_rect.w, safe.x + safe.w - right_x)
   expect_equal(result, "cards span full safe width", layout.cards_rect.w, safe.w)
-  expect_equal(result, "cards start below map panel", layout.cards_rect.y, layout.map_rect.y + layout.map_rect.h + 12)
+
+  expect_equal(result, "graph rect is inset inside map panel", layout.map_graph_rect.x, layout.map_rect.x + 14)
+  expect_equal(result, "graph rect y offset", layout.map_graph_rect.y, layout.map_rect.y + 120)
+  expect_equal(result, "graph rect width inset", layout.map_graph_rect.w, layout.map_rect.w - 28)
+  expect_equal(result, "graph rect height reserves footer", layout.map_graph_rect.h, layout.map_rect.h - 164)
+
+  expect_equal(result, "hazard card width cap", layout.hazard_card_rect.w, math.min(layout.hazard_rect.w - 20, 236))
+  expect_equal(result, "hazard card height cap", layout.hazard_card_rect.h, math.min(layout.hazard_rect.h - 42, 276))
 
   expect_equal(result, "heat and soil share x", layout.nodes.heat.x, layout.nodes.soil.x)
   expect_equal(result, "air and water share y", layout.nodes.air.y, layout.nodes.water.y)
   expect_equal(result, "all nodes share radius", layout.nodes.heat.r, layout.nodes.air.r)
+  expect_equal(result, "magnetosphere center x aligns with node axis", layout.magnetosphere.x, layout.nodes.heat.x)
+  expect_equal(result, "magnetosphere center y aligns with node axis", layout.magnetosphere.y, layout.nodes.air.y)
   return result
 end
 
@@ -64,6 +85,7 @@ local function run_controls_contract()
   expect_equal(result, "forecast button id", mode_buttons[1].id, "current")
   expect_equal(result, "preview explain button width", preview_button.w, 176)
   expect_equal(result, "objectives explain button width", objectives_button.w, 188)
+  expect_equal(result, "graph explain button remains in map footer", toggles.explain_graph.y, layout.map_rect.y + layout.map_rect.h - 34)
   return result
 end
 
@@ -86,8 +108,8 @@ local function run_card_rects_contract()
   expect_equal(result, "first option is do-nothing", card_rects[1].option.kind, "do_nothing")
   expect_equal(result, "second option is first hand card", card_rects[2].option.card_index, 1)
   expect_equal(result, "last option is fifth hand card", card_rects[6].option.card_index, 5)
-  expect_equal(result, "card width preserved", card_rects[1].w, 170)
-  expect_equal(result, "card height preserved", card_rects[1].h, 58)
+  expect_equal(result, "card width preserved", card_rects[1].w, 166)
+  expect_equal(result, "card height preserved", card_rects[1].h, 56)
   return result
 end
 

--- a/tests/influence_ui_state_spec.lua
+++ b/tests/influence_ui_state_spec.lua
@@ -35,6 +35,7 @@ local function run_default_state_contract()
   expect_equal(result, "graph explain starts hidden", state.show_graph_explain, false)
   expect_equal(result, "turn explain starts hidden", state.show_turn_explain, false)
   expect_equal(result, "objectives explain starts hidden", state.show_objectives_explain, false)
+  expect_equal(result, "help tooltip starts hidden", state.show_help_tooltip, false)
   return result
 end
 
@@ -98,6 +99,11 @@ local function run_explain_toggle_contract()
   expect_equal(result, "objectives explain toggles on independently", state.show_objectives_explain, true)
   state:toggle_objectives_explain()
   expect_equal(result, "objectives explain toggles off", state.show_objectives_explain, false)
+
+  state:toggle_help_tooltip()
+  expect_equal(result, "help tooltip toggles on", state.show_help_tooltip, true)
+  state:toggle_help_tooltip()
+  expect_equal(result, "help tooltip toggles off", state.show_help_tooltip, false)
   return result
 end
 

--- a/ui/components/gameplay_hud.lua
+++ b/ui/components/gameplay_hud.lua
@@ -1,30 +1,87 @@
 local GameplayHUD = {}
 
-local function draw_stats(opts)
-  local base_x = opts.start_x or 10
-  local base_y = opts.start_y or 110
-  local line_height = opts.show_real_world_values and 36 or 22
+local function fit_single_line(text, max_width)
+  local font = love.graphics.getFont()
+  if font:getWidth(text) <= max_width then
+    return text
+  end
 
-  for i, key in ipairs(opts.stat_order) do
-    local value = opts.terraforming_state.stats[key]
-    local target_value = opts.terraforming_state.targets[key]
-    local status, color = opts.get_stat_status(key, value)
-    local y = base_y + (i - 1) * line_height
+  local suffix = "..."
+  local suffix_w = font:getWidth(suffix)
+  local trimmed = text
+  while #trimmed > 0 and (font:getWidth(trimmed) + suffix_w) > max_width do
+    trimmed = string.sub(trimmed, 1, #trimmed - 1)
+  end
 
-    love.graphics.setColor(unpack(color))
-    love.graphics.print(
-      opts.stat_labels[key] .. ": " .. opts.format_signed(value) .. " / target " .. opts.format_signed(target_value) .. "  [" .. status .. "]",
-      base_x,
-      y
-    )
+  if #trimmed == 0 then
+    return suffix
+  end
+  return trimmed .. suffix
+end
 
-    if opts.show_real_world_values then
-      love.graphics.setColor(0.75, 0.84, 0.95, 1)
-      love.graphics.print("    " .. opts.get_real_world_mapping(key, value), base_x, y + 16)
+local function draw_industry_grid(opts)
+  local start_x = opts.start_x
+  local start_y = opts.start_y
+  local economy = opts.economy
+  local state = opts.terraforming_state
+  local cell_w = 158
+  local cell_h = 58
+  local col_gap = 8
+  local row_gap = 8
+  local header_h = 20
+  local slots = state:get_industry_slot_count()
+
+  love.graphics.setColor(0.75, 0.87, 0.95, 1)
+  love.graphics.print("Industry Slots", start_x, start_y)
+
+  for i = 1, slots do
+    local col = (i - 1) % 2
+    local row = math.floor((i - 1) / 2)
+    local x = start_x + (col * (cell_w + col_gap))
+    local y = start_y + header_h + (row * (cell_h + row_gap))
+    local industry = economy.industries[i]
+
+    local fill = { 0.08, 0.1, 0.14, 0.95 }
+    local border = { 0.48, 0.58, 0.7, 1 }
+    if industry then
+      local hp_ratio = (industry.health or 0) / math.max(1, industry.max_health or 1)
+      if hp_ratio <= 0.34 then
+        fill = { 0.24, 0.12, 0.12, 0.95 }
+        border = { 0.86, 0.45, 0.4, 1 }
+      elseif hp_ratio <= 0.67 then
+        fill = { 0.22, 0.18, 0.1, 0.95 }
+        border = { 0.93, 0.75, 0.42, 1 }
+      else
+        fill = { 0.12, 0.22, 0.15, 0.95 }
+        border = { 0.62, 0.9, 0.6, 1 }
+      end
+    end
+
+    love.graphics.setColor(unpack(fill))
+    love.graphics.rectangle("fill", x, y, cell_w, cell_h, 8, 8)
+    love.graphics.setColor(unpack(border))
+    love.graphics.rectangle("line", x, y, cell_w, cell_h, 8, 8)
+
+    if industry then
+      local base = industry.base_profit or 0
+      local pop_bonus = math.floor((economy.population or 0) * (industry.population_factor or 0) + 0.5)
+      local income = base + pop_bonus
+      local line_1 = fit_single_line(tostring(i) .. ". " .. tostring(industry.name or "Industry"), cell_w - 12)
+      local line_2 = "HP " .. tostring(industry.health or 0) .. "/" .. tostring(industry.max_health or 0)
+      local line_3 = "Income " .. opts.format_signed(income) .. "/t"
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.printf(line_1, x + 6, y + 7, cell_w - 12, "left")
+      love.graphics.printf(line_2, x + 6, y + 24, cell_w - 12, "left")
+      love.graphics.printf(line_3, x + 6, y + 40, cell_w - 12, "left")
+    else
+      love.graphics.setColor(0.75, 0.87, 0.95, 1)
+      love.graphics.printf(tostring(i) .. ". Open", x + 6, y + 11, cell_w - 12, "left")
+      love.graphics.printf("Income +0/t", x + 6, y + 33, cell_w - 12, "left")
     end
   end
 
   love.graphics.setColor(1, 1, 1, 1)
+  return start_y + header_h + (cell_h * 2) + row_gap
 end
 
 function GameplayHUD.draw_hud(opts)
@@ -66,56 +123,38 @@ function GameplayHUD.draw_hud(opts)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.print("Population: " .. tostring(economy.population) .. "    Profit: " .. tostring(economy.profit), hud_x, header_y + 60)
 
-  local stats_start_y = header_y + 80
-  draw_stats({
-    start_y = stats_start_y,
+  local industry_y = header_y + 86
+  local industry_bottom_y = draw_industry_grid({
     start_x = hud_x,
-    show_real_world_values = opts.show_real_world_values,
-    stat_order = opts.stat_order,
-    stat_labels = opts.stat_labels,
+    start_y = industry_y,
+    economy = economy,
     terraforming_state = opts.terraforming_state,
-    get_stat_status = opts.get_stat_status,
-    format_signed = opts.format_signed,
-    get_real_world_mapping = opts.get_real_world_mapping
+    format_signed = opts.format_signed
   })
-  local line_height = opts.show_real_world_values and 36 or 22
-  local stats_bottom_y = stats_start_y + (#opts.stat_order * line_height)
-  local industry_y = stats_bottom_y + 12
-
-  local slot_parts = {}
-  for i = 1, opts.terraforming_state:get_industry_slot_count() do
-    local industry = economy.industries[i]
-    if industry then
-      table.insert(slot_parts, tostring(i) .. ":" .. industry.name .. " " .. tostring(industry.health) .. "/" .. tostring(industry.max_health))
-    else
-      table.insert(slot_parts, tostring(i) .. ":Open")
-    end
-  end
-  love.graphics.print("Industry Slots: " .. table.concat(slot_parts, " | "), hud_x, industry_y)
 
   if opts.turn_summary then
     local turn_summary = opts.turn_summary
-    local summary_y = industry_y + 38
+    local summary_y = industry_bottom_y + 16
     love.graphics.print(
       "Last Turn Hazard: " .. turn_summary.hazard .. " [" .. tostring(turn_summary.hazard_category or "Hazard") .. "]",
       hud_x,
       summary_y
     )
     love.graphics.print(
-      "Hazard Raw: " .. opts.format_delta_list(turn_summary.hazard_raw_deltas or turn_summary.hazard_deltas),
+      "Last Turn Raw (pre-magnetosphere): " .. opts.format_delta_list(turn_summary.hazard_raw_deltas or turn_summary.hazard_deltas),
       hud_x,
       summary_y + 20
     )
     if turn_summary.hazard_blockable then
       love.graphics.print(
-        "Magnetosphere Block: " .. opts.format_delta_list(turn_summary.hazard_blocked_deltas) ..
-          " -> Applied " .. opts.format_delta_list(turn_summary.hazard_deltas),
+        "Last Turn Applied (post-magnetosphere): " .. opts.format_delta_list(turn_summary.hazard_deltas) ..
+          "  [Blocked " .. opts.format_delta_list(turn_summary.hazard_blocked_deltas) .. "]",
         hud_x,
         summary_y + 40
       )
       summary_y = summary_y + 20
     else
-      love.graphics.print("Applied Hazard Delta: " .. opts.format_delta_list(turn_summary.hazard_deltas), hud_x, summary_y + 40)
+      love.graphics.print("Last Turn Applied (post-magnetosphere): " .. opts.format_delta_list(turn_summary.hazard_deltas), hud_x, summary_y + 40)
     end
     love.graphics.print("Coupling Delta: " .. opts.format_delta_list(turn_summary.coupling_deltas), hud_x, summary_y + 60)
     love.graphics.print(
@@ -140,7 +179,7 @@ function GameplayHUD.draw_controls_hint(opts)
   y = opts.clamp_value(y, safe.y + 12, safe.y + safe.h - 30)
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.print(
-    "Controls: Click card | E end turn | V influence map | M real-world mapping | R restart",
+    "Controls: Click card | E end turn | V influence map | R restart",
     safe.x + 4,
     y
   )

--- a/ui/components/hazard_card.lua
+++ b/ui/components/hazard_card.lua
@@ -32,6 +32,46 @@ local function origin_label(origin)
   return labels[origin] or "Hazard"
 end
 
+local function fit_single_line(text, max_width)
+  local font = love.graphics.getFont()
+  if font:getWidth(text) <= max_width then
+    return text
+  end
+
+  local suffix = "..."
+  local suffix_w = font:getWidth(suffix)
+  local trimmed = text
+  while #trimmed > 0 and (font:getWidth(trimmed) + suffix_w) > max_width do
+    trimmed = string.sub(trimmed, 1, #trimmed - 1)
+  end
+  if #trimmed == 0 then
+    return suffix
+  end
+  return trimmed .. suffix
+end
+
+local function draw_wrapped_limited(text, x, y, width, color, max_lines)
+  love.graphics.setColor(unpack(color or { 1, 1, 1, 1 }))
+  local font = love.graphics.getFont()
+  local _, wrapped = font:getWrap(text, width)
+  local lines = wrapped
+  local keep = max_lines or #lines
+  if #lines > keep then
+    local clipped = {}
+    for i = 1, keep do
+      clipped[i] = lines[i]
+    end
+    clipped[keep] = fit_single_line(clipped[keep], width)
+    lines = clipped
+  end
+
+  local line_h = font:getHeight() + 2
+  for i = 1, #lines do
+    love.graphics.print(lines[i], x, y + ((i - 1) * line_h))
+  end
+  return y + (#lines * line_h)
+end
+
 function HazardCard.draw(opts)
   local rect = opts.rect
   local target = opts.target
@@ -46,9 +86,10 @@ function HazardCard.draw(opts)
   local accent = origin_color(hazard.origin)
   local body_color = { 0.07, 0.09, 0.13, 0.95 }
   local border_color = { accent[1], accent[2], accent[3], 1 }
-  local header_h = 24
+  local header_h = 28
   local text_x = rect.x + 8
   local text_w = rect.w - 16
+  local art_h = math.max(52, math.floor(rect.h * 0.26))
 
   love.graphics.setColor(unpack(body_color))
   love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 8, 8)
@@ -60,30 +101,68 @@ function HazardCard.draw(opts)
   love.graphics.setColor(accent[1], accent[2], accent[3], 0.86)
   love.graphics.rectangle("fill", rect.x, rect.y, rect.w, header_h, 8, 8)
   love.graphics.setColor(0.03, 0.05, 0.08, 1)
-  love.graphics.printf("INCOMING", rect.x + 4, rect.y + 6, rect.w - 8, "center")
+  love.graphics.printf("INCOMING", rect.x + 4, rect.y + 8, rect.w - 8, "center")
 
-  local line_y = rect.y + header_h + 6
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.printf(hazard.name or "Hazard", text_x, line_y, text_w, "center")
-  line_y = line_y + 30
+  local line_y = rect.y + header_h + 7
+  line_y = draw_wrapped_limited(fit_single_line(hazard.name or "Hazard", text_w), text_x, line_y, text_w, { 1, 1, 1, 1 }, 1)
+  line_y = draw_wrapped_limited(
+    fit_single_line((hazard.category or "Event") .. " | " .. origin_label(hazard.origin), text_w),
+    text_x,
+    line_y,
+    text_w,
+    { 0.76, 0.87, 0.95, 1 },
+    1
+  )
+  line_y = line_y + 3
 
-  love.graphics.setColor(0.76, 0.87, 0.95, 1)
-  love.graphics.printf((hazard.category or "Event") .. " | " .. origin_label(hazard.origin), text_x, line_y, text_w, "center")
-  line_y = line_y + 28
+  local art_x = text_x
+  local art_y = line_y
+  local art_w = text_w
+  love.graphics.setColor(0.09, 0.11, 0.16, 0.95)
+  love.graphics.rectangle("fill", art_x, art_y, art_w, art_h, 6, 6)
+  love.graphics.setColor(accent[1], accent[2], accent[3], 0.55)
+  love.graphics.rectangle("line", art_x, art_y, art_w, art_h, 6, 6)
 
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.printf("Raw: " .. format_delta_list(projection.raw_deltas), text_x, line_y, text_w, "left")
-  line_y = line_y + 30
+  love.graphics.setScissor(art_x + 1, art_y + 1, art_w - 2, art_h - 2)
+  love.graphics.setLineWidth(2)
+  if hazard.origin == "space" then
+    love.graphics.setColor(accent[1], accent[2], accent[3], 0.85)
+    love.graphics.line(art_x + 10, art_y + art_h - 8, art_x + art_w - 18, art_y + 10)
+    love.graphics.circle("fill", art_x + art_w - 22, art_y + 12, 5)
+    love.graphics.setColor(1, 0.94, 0.74, 0.7)
+    love.graphics.circle("fill", art_x + art_w - 22, art_y + 12, 3)
+  elseif hazard.origin == "biological" then
+    love.graphics.setColor(accent[1], accent[2], accent[3], 0.85)
+    love.graphics.circle("line", art_x + 24, art_y + 16, 8)
+    love.graphics.circle("line", art_x + 40, art_y + 28, 10)
+    love.graphics.circle("line", art_x + 58, art_y + 17, 7)
+  else
+    love.graphics.setColor(accent[1], accent[2], accent[3], 0.8)
+    for i = 0, 2 do
+      local wave_y = art_y + 10 + (i * 10)
+      love.graphics.line(art_x + 8, wave_y, art_x + art_w - 8, wave_y + 3 + (pulse * 2))
+    end
+  end
+  love.graphics.setLineWidth(1)
+  love.graphics.setScissor()
+  line_y = line_y + art_h + 8
+
+  line_y = draw_wrapped_limited("Raw: " .. format_delta_list(projection.raw_deltas), text_x, line_y, text_w, { 1, 1, 1, 1 }, 2)
+  line_y = line_y + 1
 
   if hazard.magnetosphere_blockable then
-    love.graphics.setColor(0.68, 0.87, 1, 1)
-    love.graphics.printf("Mag L" .. tostring(magnetosphere_level) .. " (" .. magnetosphere_tier .. ")", text_x, line_y, text_w, "left")
-    line_y = line_y + 18
-    love.graphics.setColor(0.86, 0.93, 1, 1)
-    love.graphics.printf("After block: " .. format_delta_list(projection.effective_deltas), text_x, line_y, text_w, "left")
+    line_y = draw_wrapped_limited(
+      "Magnetosphere: L" .. tostring(magnetosphere_level) .. " (" .. magnetosphere_tier .. ")",
+      text_x,
+      line_y,
+      text_w,
+      { 0.68, 0.87, 1, 1 },
+      1
+    )
+    draw_wrapped_limited("Applied: " .. format_delta_list(projection.effective_deltas), text_x, line_y, text_w, { 0.86, 0.93, 1, 1 }, 2)
   else
-    love.graphics.setColor(0.9, 0.78, 0.42, 1)
-    love.graphics.printf("Bypasses magnetosphere", text_x, line_y, text_w, "left")
+    line_y = draw_wrapped_limited("Bypasses magnetosphere", text_x, line_y, text_w, { 0.9, 0.78, 0.42, 1 }, 1)
+    draw_wrapped_limited("Applied: " .. format_delta_list(projection.effective_deltas), text_x, line_y, text_w, { 0.86, 0.93, 1, 1 }, 2)
   end
 
   if show_target_vector and target then

--- a/ui/components/hazard_card.lua
+++ b/ui/components/hazard_card.lua
@@ -35,6 +35,7 @@ end
 function HazardCard.draw(opts)
   local rect = opts.rect
   local target = opts.target
+  local show_target_vector = opts.show_target_vector ~= false
   local projection = opts.projection or {}
   local hazard = projection.hazard or {}
   local format_delta_list = opts.format_delta_list
@@ -85,34 +86,36 @@ function HazardCard.draw(opts)
     love.graphics.printf("Bypasses magnetosphere", text_x, line_y, text_w, "left")
   end
 
-  local start_x = rect.x + rect.w + 8
-  local start_y = rect.y + math.floor(rect.h * 0.5)
-  local end_x = target.x - target.radius - 10
-  local end_y = target.y
-  local dx = end_x - start_x
-  local dy = end_y - start_y
-  local length = math.sqrt(dx * dx + dy * dy)
-  if length > 0 then
-    local ux = dx / length
-    local uy = dy / length
-    local arrow_len = 9
-    local base_x = end_x - ux * 8
-    local base_y = end_y - uy * 8
-    local perp_x = -uy
-    local perp_y = ux
-    love.graphics.setColor(accent[1], accent[2], accent[3], 0.45 + pulse * 0.45)
-    love.graphics.setLineWidth(2)
-    love.graphics.line(start_x, start_y, end_x, end_y)
-    love.graphics.polygon(
-      "fill",
-      end_x,
-      end_y,
-      base_x + perp_x * (arrow_len * 0.45),
-      base_y + perp_y * (arrow_len * 0.45),
-      base_x - perp_x * (arrow_len * 0.45),
-      base_y - perp_y * (arrow_len * 0.45)
-    )
-    love.graphics.setLineWidth(1)
+  if show_target_vector and target then
+    local start_x = rect.x + rect.w + 8
+    local start_y = rect.y + math.floor(rect.h * 0.5)
+    local end_x = target.x - target.radius - 10
+    local end_y = target.y
+    local dx = end_x - start_x
+    local dy = end_y - start_y
+    local length = math.sqrt(dx * dx + dy * dy)
+    if length > 0 then
+      local ux = dx / length
+      local uy = dy / length
+      local arrow_len = 9
+      local base_x = end_x - ux * 8
+      local base_y = end_y - uy * 8
+      local perp_x = -uy
+      local perp_y = ux
+      love.graphics.setColor(accent[1], accent[2], accent[3], 0.45 + pulse * 0.45)
+      love.graphics.setLineWidth(2)
+      love.graphics.line(start_x, start_y, end_x, end_y)
+      love.graphics.polygon(
+        "fill",
+        end_x,
+        end_y,
+        base_x + perp_x * (arrow_len * 0.45),
+        base_y + perp_y * (arrow_len * 0.45),
+        base_x - perp_x * (arrow_len * 0.45),
+        base_y - perp_y * (arrow_len * 0.45)
+      )
+      love.graphics.setLineWidth(1)
+    end
   end
 end
 

--- a/ui/components/objectives_panel.lua
+++ b/ui/components/objectives_panel.lua
@@ -131,7 +131,9 @@ local function draw_wrapped_line(text, x, y, width, color, line_height)
   love.graphics.printf(text, x, y, width, "left")
   local font = love.graphics.getFont()
   local _, wrapped = font:getWrap(text, width)
-  return y + (math.max(1, #wrapped) * (line_height or 16))
+  local font_h = font:getHeight()
+  local effective_line_height = math.max(line_height or font_h, font_h + 2)
+  return y + (math.max(1, #wrapped) * effective_line_height)
 end
 
 local function fit_single_line(text, max_width)

--- a/ui/components/objectives_panel.lua
+++ b/ui/components/objectives_panel.lua
@@ -110,16 +110,41 @@ local function draw_end_objective_metric_graph(rect, y, label, current_value, ac
 
   love.graphics.setColor(0.08, 0.1, 0.14, 1)
   love.graphics.rectangle("fill", bar_x, bar_y, bar_w, bar_h, 5, 5)
+  local inner_x = bar_x + 1
+  local inner_y = bar_y + 1
+  local inner_w = bar_w - 2
+  local inner_h = bar_h - 2
   love.graphics.setColor(bar_color[1], bar_color[2], bar_color[3], 0.95)
-  love.graphics.rectangle("fill", bar_x + 1, bar_y + 1, math.floor((bar_w - 2) * current_t), bar_h - 2, 4, 4)
+  love.graphics.rectangle("fill", inner_x, inner_y, math.floor(inner_w * current_t), inner_h, 4, 4)
+
+  if active_t ~= current_t then
+    local projection_start_t = math.min(current_t, active_t)
+    local projection_end_t = math.max(current_t, active_t)
+    local projection_x = inner_x + math.floor(inner_w * projection_start_t)
+    local projection_w = math.max(2, math.floor(inner_w * (projection_end_t - projection_start_t)))
+    local is_gain = active_t > current_t
+
+    local fill = is_gain and { 0.32, 0.58, 0.86, 0.26 } or { 0.84, 0.42, 0.42, 0.24 }
+    local stripe = is_gain and { 0.6, 0.84, 1.0, 0.55 } or { 1.0, 0.7, 0.66, 0.52 }
+    love.graphics.setColor(unpack(fill))
+    love.graphics.rectangle("fill", projection_x, inner_y, projection_w, inner_h, 3, 3)
+
+    love.graphics.setScissor(projection_x, inner_y, projection_w, inner_h)
+    love.graphics.setColor(unpack(stripe))
+    for sx = projection_x - inner_h, projection_x + projection_w + inner_h, 8 do
+      love.graphics.line(sx, inner_y + inner_h, sx + inner_h, inner_y)
+    end
+    love.graphics.setScissor()
+  end
+
   love.graphics.setColor(0.72, 0.82, 0.96, 1)
   love.graphics.rectangle("line", bar_x, bar_y, bar_w, bar_h, 5, 5)
 
-  local marker_x = bar_x + math.floor((bar_w - 2) * active_t)
-  love.graphics.setColor(0.48, 0.74, 1.0, 1)
-  love.graphics.setLineWidth(2)
-  love.graphics.line(marker_x, bar_y - 1, marker_x, bar_y + bar_h + 1)
-  love.graphics.setLineWidth(1)
+  if active_t ~= current_t then
+    local marker_x = inner_x + math.floor(inner_w * active_t)
+    love.graphics.setColor(0.48, 0.74, 1.0, 1)
+    love.graphics.circle("fill", marker_x, bar_y + math.floor(bar_h * 0.5), 3)
+  end
 end
 
 local function draw_wrapped_line(text, x, y, width, color, line_height)
@@ -402,7 +427,7 @@ function ObjectivesPanel.draw(opts)
   local primitive_header_y = rect.y + 56
   local tile_gap = 8
   local tile_w = math.floor((rect.w - 28 - (tile_gap * 3)) / 4)
-  local tile_h = 52
+  local tile_h = 56
   local tile_y = primitive_header_y + 16
 
   love.graphics.setColor(0.75, 0.87, 0.95, 1)
@@ -418,20 +443,26 @@ function ObjectivesPanel.draw(opts)
     love.graphics.setColor(unpack(border_color))
     love.graphics.rectangle("line", tile_x, tile_y, tile_w, tile_h, 8, 8)
     love.graphics.setColor(1, 1, 1, 1)
-    love.graphics.printf(opts.stat_labels[key], tile_x + 6, tile_y + 5, tile_w - 12, "center")
-    love.graphics.printf("Now " .. opts.format_signed(active_score) .. " " .. get_quality_label(active_quality), tile_x + 6, tile_y + 20, tile_w - 12, "center")
+    local line_1 = fit_single_line(opts.stat_labels[key], tile_w - 12)
+    local line_2 = fit_single_line("Now " .. opts.format_signed(active_score) .. " " .. get_quality_label(active_quality), tile_w - 12)
     local score_text = "From " .. opts.format_signed(current_score)
     if active_score ~= current_score then
-      score_text = score_text .. " -> " .. opts.format_signed(active_score)
+      score_text = score_text .. " to " .. opts.format_signed(active_score)
     end
-    love.graphics.printf(score_text, tile_x + 6, tile_y + 35, tile_w - 12, "center")
+    local line_3 = fit_single_line(score_text, tile_w - 12)
+    love.graphics.printf(line_1, tile_x + 6, tile_y + 5, tile_w - 12, "center")
+    love.graphics.printf(line_2, tile_x + 6, tile_y + 21, tile_w - 12, "center")
+    love.graphics.printf(line_3, tile_x + 6, tile_y + 37, tile_w - 12, "center")
   end
 
-  local bars_y = tile_y + tile_h + 10
+  local bars_y = tile_y + tile_h + 8
   draw_end_objective_metric_graph(rect, bars_y, "Population", current_population, active_population, { 0.35, 0.66, 0.42 }, opts.format_signed, opts.clamp_value)
-  draw_end_objective_metric_graph(rect, bars_y + 48, "Profit", current_profit, active_profit, { 0.66, 0.56, 0.24 }, opts.format_signed, opts.clamp_value)
+  love.graphics.setColor(0.72, 0.82, 0.96, 1)
+  local pop_breakdown = "Delta: +1 base + " .. opts.format_signed(active_breakdown.primitive) .. " primitive + " .. opts.format_signed(active_breakdown.synergy) .. " synergy"
+  love.graphics.printf(pop_breakdown, rect.x + 14, bars_y + 34, rect.w - 28, "left")
+  draw_end_objective_metric_graph(rect, bars_y + 58, "Profit", current_profit, active_profit, { 0.66, 0.56, 0.24 }, opts.format_signed, opts.clamp_value)
 
-  local flow_title_y = bars_y + 90
+  local flow_title_y = bars_y + 144
   love.graphics.setColor(0.75, 0.87, 0.95, 1)
   love.graphics.printf("Profit Flow", rect.x + 14, flow_title_y, rect.w - 28, "left")
 
@@ -460,8 +491,8 @@ function ObjectivesPanel.draw(opts)
     love.graphics.setColor(unpack(border))
     love.graphics.rectangle("line", box_x, flow_y, flow_box_w, flow_box_h, 7, 7)
     love.graphics.setColor(1, 1, 1, 1)
-    love.graphics.printf(item.title, box_x + 6, flow_y + 7, flow_box_w - 12, "center")
-    love.graphics.printf(item.value, box_x + 6, flow_y + 22, flow_box_w - 12, "center")
+    love.graphics.printf(fit_single_line(item.title, flow_box_w - 12), box_x + 6, flow_y + 7, flow_box_w - 12, "center")
+    love.graphics.printf(fit_single_line(item.value, flow_box_w - 12), box_x + 6, flow_y + 22, flow_box_w - 12, "center")
   end
 
   for i = 1, 2 do

--- a/ui/components/objectives_panel.lua
+++ b/ui/components/objectives_panel.lua
@@ -370,8 +370,6 @@ function ObjectivesPanel.draw(opts)
   local current_profit = forecast_ctx.current_economy.profit
   local active_population = forecast_ctx.active_economy.population
   local active_profit = forecast_ctx.active_economy.profit
-  local magnetosphere_level = opts.terraforming_state:get_magnetosphere_level()
-  local magnetosphere_tier = opts.terraforming_state:get_magnetosphere_tier(magnetosphere_level)
   local slot_count = opts.terraforming_state:get_industry_slot_count()
   local active_industries = forecast_ctx.active_economy.industries or {}
   local current_breakdown = build_population_snapshot_breakdown(opts.terraforming_state, opts.stat_order, opts.terraforming_state.stats or {})
@@ -394,8 +392,7 @@ function ObjectivesPanel.draw(opts)
   love.graphics.setColor(0.75, 0.87, 0.95, 1)
   love.graphics.printf(
     "Mode: " .. mode_text ..
-      "  |  Hab " .. tostring(opts.terraforming_state.habitability) .. "/" .. tostring(opts.terraforming_state.goal) ..
-      "  |  Mag L" .. tostring(magnetosphere_level) .. " " .. magnetosphere_tier,
+      "  |  Hab " .. tostring(opts.terraforming_state.habitability) .. "/" .. tostring(opts.terraforming_state.goal),
     rect.x + 14,
     rect.y + 34,
     rect.w - 28,

--- a/ui/components/primitive_snapshot.lua
+++ b/ui/components/primitive_snapshot.lua
@@ -1,0 +1,89 @@
+local PrimitiveSnapshot = {}
+
+local OFFSETS = {
+  heat = { x = 0, y = -74 },
+  air = { x = -86, y = 0 },
+  water = { x = 86, y = 0 },
+  soil = { x = 0, y = 74 }
+}
+
+local function fit_single_line(text, max_width)
+  local font = love.graphics.getFont()
+  if font:getWidth(text) <= max_width then
+    return text
+  end
+
+  local suffix = "..."
+  local suffix_w = font:getWidth(suffix)
+  local trimmed = text
+  while #trimmed > 0 and (font:getWidth(trimmed) + suffix_w) > max_width do
+    trimmed = string.sub(trimmed, 1, #trimmed - 1)
+  end
+
+  if #trimmed == 0 then
+    return suffix
+  end
+  return trimmed .. suffix
+end
+
+function PrimitiveSnapshot.draw(opts)
+  if not opts then
+    return
+  end
+
+  local center_x = opts.center_x
+  local center_y = opts.center_y
+  local stats = opts.stats or {}
+  local stat_order = opts.stat_order or {}
+  local stat_labels = opts.stat_labels or {}
+  local get_stat_status = opts.get_stat_status
+  local format_signed = opts.format_signed
+  local radius = opts.node_radius or 30
+
+  if not center_x or not center_y or not get_stat_status or not format_signed then
+    return
+  end
+
+  local shell_color = opts.shell_color or { 0.28, 0.62, 0.95, 0.16 }
+  love.graphics.setColor(unpack(shell_color))
+  for i = 1, 3 do
+    local shell_r = radius + 24 + (i * 9)
+    love.graphics.circle("line", center_x, center_y, shell_r)
+  end
+
+  for _, key in ipairs(stat_order) do
+    local offset = OFFSETS[key]
+    if offset then
+      local value = stats[key] or 0
+      local status, color = get_stat_status(key, value)
+      local node_x = center_x + offset.x
+      local node_y = center_y + offset.y
+
+      love.graphics.setColor(0.08, 0.1, 0.14, 0.95)
+      love.graphics.circle("fill", node_x, node_y, radius)
+      love.graphics.setColor(color[1], color[2], color[3], 1)
+      love.graphics.setLineWidth(2.5)
+      love.graphics.circle("line", node_x, node_y, radius)
+      love.graphics.setLineWidth(1)
+
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.printf(stat_labels[key] or key, node_x - radius + 8, node_y - 16, (radius * 2) - 16, "center")
+      love.graphics.printf(format_signed(value), node_x - radius + 8, node_y + 1, (radius * 2) - 16, "center")
+
+      local status_w = math.max(96, (radius * 2) + 26)
+      local status_h = 16
+      local status_x = node_x - math.floor(status_w * 0.5)
+      local status_y = node_y + radius + 7
+      love.graphics.setColor(0.06, 0.08, 0.12, 0.88)
+      love.graphics.rectangle("fill", status_x, status_y, status_w, status_h, 7, 7)
+      love.graphics.setColor(color[1], color[2], color[3], 0.95)
+      love.graphics.rectangle("line", status_x, status_y, status_w, status_h, 7, 7)
+      love.graphics.setColor(0.83, 0.9, 0.98, 1)
+      love.graphics.printf(fit_single_line(status, status_w - 10), status_x + 5, status_y + 2, status_w - 10, "center")
+    end
+  end
+
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+return PrimitiveSnapshot

--- a/ui/layout/gameplay_layout.lua
+++ b/ui/layout/gameplay_layout.lua
@@ -63,17 +63,18 @@ function GameplayLayout.get_discard_rect(safe_rect, pile_ui)
   }
 end
 
-function GameplayLayout.get_end_turn_rect(safe_rect, hand_layout, hand_ui, end_turn_ui)
+function GameplayLayout.get_end_turn_rect(safe_rect, hand_layout, hand_ui, end_turn_ui, pile_ui)
   local safe = safe_rect
-  local hand = hand_ui or {}
   local end_turn = end_turn_ui or {}
-  local h = end_turn.height or 50
-  local w = end_turn.width or 170
-  local card_h = hand.card_height or 225
-  local y = hand_layout.base_y + math.floor((card_h - h) * 0.5)
+  local h = end_turn.height or 44
+  local w = end_turn.width or 142
+  local discard = GameplayLayout.get_discard_rect(safe, pile_ui)
+  local x = discard.x + math.floor((discard.w - w) * 0.5)
+  local y = discard.y - h - 14
+  x = clamp_value(x, safe.x + 14, safe.x + safe.w - w - 14)
   y = clamp_value(y, safe.y + 14, safe.y + safe.h - h - 14)
   return {
-    x = safe.x + safe.w - w - 16,
+    x = x,
     y = y,
     w = w,
     h = h
@@ -82,8 +83,8 @@ end
 
 function GameplayLayout.get_hazard_card_rect(safe_rect, planet)
   local safe = safe_rect
-  local card_w = 132
-  local card_h = 170
+  local card_w = 170
+  local card_h = 236
   local desired_x = planet.x - planet.radius - card_w - 24
   local min_x = safe.x + 16
   local max_x = safe.x + safe.w - card_w - 16
@@ -115,7 +116,7 @@ function GameplayLayout.compute(safe_rect, ui_state)
     hand = hand_layout,
     deck = GameplayLayout.get_deck_rect(safe, pile),
     discard = GameplayLayout.get_discard_rect(safe, pile),
-    end_turn = GameplayLayout.get_end_turn_rect(safe, hand_layout, hand, end_turn),
+    end_turn = GameplayLayout.get_end_turn_rect(safe, hand_layout, hand, end_turn, pile),
     incoming_hazard = GameplayLayout.get_hazard_card_rect(safe, planet)
   }
 end

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -1,23 +1,60 @@
 local InfluenceLayout = {}
 
+local function clamp_value(value, min_value, max_value)
+  if value < min_value then
+    return min_value
+  end
+  if value > max_value then
+    return max_value
+  end
+  return value
+end
+
 function InfluenceLayout.compute(safe_rect)
   local safe = safe_rect
   local panel_gap = 14
   local top_y = safe.y + 76
-  local top_h = math.floor(safe.h * 0.62)
-  local map_w = math.floor(safe.w * 0.54)
-  local map_rect = {
+  local cards_h = clamp_value(math.floor(safe.h * 0.24), 170, 196)
+  local cards_y = safe.y + safe.h - cards_h
+  local top_h = cards_y - top_y - 12
+
+  local hazard_w = math.max(220, math.floor(safe.w * 0.18))
+  local objectives_w = math.max(430, math.floor(safe.w * 0.285))
+  local map_w = safe.w - hazard_w - objectives_w - (panel_gap * 2)
+  if map_w < 520 then
+    local deficit = 520 - map_w
+    objectives_w = math.max(360, objectives_w - deficit)
+    map_w = safe.w - hazard_w - objectives_w - (panel_gap * 2)
+  end
+
+  local hazard_rect = {
     x = safe.x,
+    y = top_y,
+    w = hazard_w,
+    h = top_h
+  }
+
+  local map_rect = {
+    x = hazard_rect.x + hazard_rect.w + panel_gap,
     y = top_y,
     w = map_w,
     h = top_h
   }
 
-  local map_center_x = map_rect.x + math.floor(map_rect.w * 0.5)
-  local map_center_y = map_rect.y + math.floor(map_rect.h * 0.6)
-  local offset_x = math.floor(map_rect.w * 0.29)
-  local offset_y = math.floor(map_rect.h * 0.24)
-  local node_radius = math.max(48, math.floor(math.min(map_rect.w, map_rect.h) * 0.11))
+  local map_header_h = 120
+  local map_footer_h = 44
+  local map_graph_rect = {
+    x = map_rect.x + 14,
+    y = map_rect.y + map_header_h,
+    w = map_rect.w - 28,
+    h = map_rect.h - map_header_h - map_footer_h
+  }
+
+  local map_center_x = map_graph_rect.x + math.floor(map_graph_rect.w * 0.5)
+  local map_center_y = map_graph_rect.y + math.floor(map_graph_rect.h * 0.52)
+  local offset_x = math.floor(map_graph_rect.w * 0.29)
+  local offset_y = math.floor(map_graph_rect.h * 0.24)
+  local node_radius = math.max(42, math.floor(math.min(map_graph_rect.w, map_graph_rect.h) * 0.11))
   local nodes = {
     heat = { x = map_center_x, y = map_center_y - offset_y, r = node_radius },
     water = { x = map_center_x + offset_x, y = map_center_y, r = node_radius },
@@ -35,30 +72,49 @@ function InfluenceLayout.compute(safe_rect)
   }
 
   local graph_explain_rect = {
-    x = map_rect.x + 22,
-    y = map_rect.y + 92,
-    w = map_rect.w - 44,
-    h = map_rect.h - 120
+    x = map_graph_rect.x + 8,
+    y = map_graph_rect.y + 8,
+    w = map_graph_rect.w - 16,
+    h = map_graph_rect.h - 16
   }
 
   local turn_explain_rect = {
     x = safe.x + 12,
-    y = map_rect.y + 92,
+    y = map_rect.y + 98,
     w = safe.w - 24,
-    h = map_rect.h - 82
+    h = map_rect.h - 90
   }
 
-  local cards_y = map_rect.y + map_rect.h + 12
   local cards_rect = {
     x = safe.x,
     y = cards_y,
     w = safe.w,
-    h = (safe.y + safe.h) - cards_y
+    h = cards_h
+  }
+
+  local magnetosphere_base_r = math.floor(math.sqrt(offset_x * offset_x + offset_y * offset_y) + node_radius + 22)
+  local magnetosphere = {
+    x = map_center_x,
+    y = map_center_y,
+    base_r = magnetosphere_base_r
+  }
+
+  local hazard_card_w = math.min(hazard_rect.w - 20, 236)
+  local hazard_card_h = math.min(hazard_rect.h - 42, 276)
+  local hazard_card_rect = {
+    x = hazard_rect.x + math.floor((hazard_rect.w - hazard_card_w) * 0.5),
+    y = hazard_rect.y + 30,
+    w = hazard_card_w,
+    h = hazard_card_h
   }
 
   return {
+    hazard_rect = hazard_rect,
+    hazard_card_rect = hazard_card_rect,
     map_rect = map_rect,
+    map_graph_rect = map_graph_rect,
     nodes = nodes,
+    magnetosphere = magnetosphere,
     objectives_rect = objectives_rect,
     graph_explain_rect = graph_explain_rect,
     turn_explain_rect = turn_explain_rect,
@@ -125,10 +181,10 @@ function InfluenceLayout.get_card_rects(layout, hand)
   end
 
   local rect = layout.cards_rect
-  local card_w = 170
-  local card_h = 58
+  local card_w = 166
+  local card_h = 56
   local gap_x = 12
-  local gap_y = 10
+  local gap_y = 8
   local footer_reserved = 42
   local cards_per_row = math.max(1, math.floor((rect.w - 20 + gap_x) / (card_w + gap_x)))
   local max_rows = math.max(1, math.floor((rect.h - 34 - footer_reserved + gap_y) / (card_h + gap_y)))

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -13,7 +13,7 @@ end
 function InfluenceLayout.compute(safe_rect)
   local safe = safe_rect
   local panel_gap = 14
-  local top_y = safe.y + 76
+  local top_y = safe.y + 50
   local cards_h = clamp_value(math.floor(safe.h * 0.24), 170, 196)
   local cards_y = safe.y + safe.h - cards_h
   local top_h = cards_y - top_y - 12
@@ -159,9 +159,19 @@ end
 function InfluenceLayout.get_preview_explain_button(layout)
   local rect = layout.cards_rect
   return {
-    x = rect.x + 12,
+    x = rect.x + 44,
     y = rect.y + rect.h - 30,
     w = 176,
+    h = 24
+  }
+end
+
+function InfluenceLayout.get_help_button(layout)
+  local rect = layout.cards_rect
+  return {
+    x = rect.x + 12,
+    y = rect.y + rect.h - 30,
+    w = 24,
     h = 24
   }
 end

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -13,8 +13,8 @@ end
 function InfluenceLayout.compute(safe_rect)
   local safe = safe_rect
   local panel_gap = 14
-  local top_y = safe.y + 50
-  local cards_h = clamp_value(math.floor(safe.h * 0.24), 170, 196)
+  local top_y = safe.y + 44
+  local cards_h = clamp_value(math.floor(safe.h * 0.20), 150, 170)
   local cards_y = safe.y + safe.h - cards_h
   local top_h = cards_y - top_y - 12
 
@@ -41,7 +41,7 @@ function InfluenceLayout.compute(safe_rect)
     h = top_h
   }
 
-  local map_header_h = 132
+  local map_header_h = 118
   local map_footer_h = 44
   local map_graph_rect = {
     x = map_rect.x + 14,
@@ -53,8 +53,8 @@ function InfluenceLayout.compute(safe_rect)
   local map_center_x = map_graph_rect.x + math.floor(map_graph_rect.w * 0.5)
   local map_center_y = map_graph_rect.y + math.floor(map_graph_rect.h * 0.52)
   local offset_x = math.floor(map_graph_rect.w * 0.29)
-  local offset_y = math.floor(map_graph_rect.h * 0.24)
-  local node_radius = math.max(48, math.floor(math.min(map_graph_rect.w, map_graph_rect.h) * 0.125))
+  local offset_y = math.floor(map_graph_rect.h * 0.29)
+  local node_radius = math.max(50, math.floor(math.min(map_graph_rect.w, map_graph_rect.h) * 0.13))
   local nodes = {
     heat = { x = map_center_x, y = map_center_y - offset_y, r = node_radius },
     water = { x = map_center_x + offset_x, y = map_center_y, r = node_radius },

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -54,7 +54,7 @@ function InfluenceLayout.compute(safe_rect)
   local map_center_y = map_graph_rect.y + math.floor(map_graph_rect.h * 0.52)
   local offset_x = math.floor(map_graph_rect.w * 0.29)
   local offset_y = math.floor(map_graph_rect.h * 0.24)
-  local node_radius = math.max(42, math.floor(math.min(map_graph_rect.w, map_graph_rect.h) * 0.11))
+  local node_radius = math.max(48, math.floor(math.min(map_graph_rect.w, map_graph_rect.h) * 0.125))
   local nodes = {
     heat = { x = map_center_x, y = map_center_y - offset_y, r = node_radius },
     water = { x = map_center_x + offset_x, y = map_center_y, r = node_radius },
@@ -92,7 +92,7 @@ function InfluenceLayout.compute(safe_rect)
     h = cards_h
   }
 
-  local magnetosphere_base_r = math.floor(math.sqrt(offset_x * offset_x + offset_y * offset_y) + node_radius + 22)
+  local magnetosphere_base_r = math.floor(math.max(offset_x + node_radius, offset_y + node_radius) + 10)
   local magnetosphere = {
     x = map_center_x,
     y = map_center_y,
@@ -100,10 +100,15 @@ function InfluenceLayout.compute(safe_rect)
   }
 
   local hazard_card_w = math.min(hazard_rect.w - 20, 236)
-  local hazard_card_h = math.min(hazard_rect.h - 42, 276)
+  local hazard_card_h = math.max(190, math.min(hazard_rect.h - 62, 266))
+  local hazard_card_y = hazard_rect.y + 42
+  local hazard_bottom = hazard_rect.y + hazard_rect.h - 10
+  if hazard_card_y + hazard_card_h > hazard_bottom then
+    hazard_card_h = math.max(160, hazard_bottom - hazard_card_y)
+  end
   local hazard_card_rect = {
     x = hazard_rect.x + math.floor((hazard_rect.w - hazard_card_w) * 0.5),
-    y = hazard_rect.y + 30,
+    y = hazard_card_y,
     w = hazard_card_w,
     h = hazard_card_h
   }

--- a/ui/layout/influence_layout.lua
+++ b/ui/layout/influence_layout.lua
@@ -41,7 +41,7 @@ function InfluenceLayout.compute(safe_rect)
     h = top_h
   }
 
-  local map_header_h = 120
+  local map_header_h = 132
   local map_footer_h = 44
   local map_graph_rect = {
     x = map_rect.x + 14,


### PR DESCRIPTION
## Summary
- fixed core influence graph text/legend overlap by using font-aware vertical spacing
- rebalanced influence screen layout to free space: added left incoming hazard column, reduced objectives width, and compacted preview selector height
- added a subtle magnetosphere field visual around the primitive cluster in the influence graph
- rendered incoming hazard card directly on the influence screen (with magnetosphere context and hazard-to-core direction)
- kept behavior/mechanics unchanged; this is a UI/layout pass only

## Layout changes
- influence layout now allocates three top columns: incoming hazard, core graph, and end objectives
- preview selector panel is shorter and card option tiles are slightly more compact
- graph explain area now anchors to the graph region (reduces clipping/overlap)

## Stability updates
- wrapped-line rendering now uses font-aware line spacing to prevent text collisions at higher DPI/font sizes
- updated influence layout spec assertions to match the new geometry contract

## Validation
- lua tests/run_math_suite.lua
- lua tests/run_math_spec.lua
- lua tests/run_characterization.lua